### PR TITLE
Support typed numeric literals

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -112,9 +112,33 @@ pub struct Literal {
 
 #[derive(Debug, Clone)]
 pub enum LiteralValue {
-    Int(i64),
-    Float(f64),
+    Int(IntLiteral),
+    Float(FloatLiteral),
     Bool(bool),
+}
+
+#[derive(Debug, Clone)]
+pub struct IntLiteral {
+    pub value: i64,
+    pub suffix: Option<IntSuffix>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IntSuffix {
+    I32,
+    I64,
+}
+
+#[derive(Debug, Clone)]
+pub struct FloatLiteral {
+    pub value: f64,
+    pub suffix: Option<FloatSuffix>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FloatSuffix {
+    F32,
+    F64,
 }
 
 #[derive(Debug, Clone)]

--- a/src/codegen/wat.rs
+++ b/src/codegen/wat.rs
@@ -216,20 +216,29 @@ impl<'a> FunctionEmitter<'a> {
 
     fn emit_expression(&mut self, expr: &Expression) -> Result<(), CompileError> {
         match expr {
-            Expression::Literal(lit) => {
-                match &lit.value {
-                    LiteralValue::Int(value) => {
-                        self.push_line(&format!("i32.const {}", value));
-                    }
-                    LiteralValue::Float(value) => {
-                        self.push_line(&format!("f32.const {}", *value as f32));
-                    }
-                    LiteralValue::Bool(value) => {
-                        self.push_line(&format!("i32.const {}", if *value { 1 } else { 0 }));
-                    }
+            Expression::Literal(lit) => match (lit.ty, &lit.value) {
+                (Type::I32, LiteralValue::Int(value)) => {
+                    self.push_line(&format!("i32.const {}", value));
+                    Ok(())
                 }
-                Ok(())
-            }
+                (Type::I64, LiteralValue::Int(value)) => {
+                    self.push_line(&format!("i64.const {}", value));
+                    Ok(())
+                }
+                (Type::F32, LiteralValue::Float(value)) => {
+                    self.push_line(&format!("f32.const {}", *value as f32));
+                    Ok(())
+                }
+                (Type::F64, LiteralValue::Float(value)) => {
+                    self.push_line(&format!("f64.const {}", value));
+                    Ok(())
+                }
+                (Type::Bool, LiteralValue::Bool(value)) => {
+                    self.push_line(&format!("i32.const {}", if *value { 1 } else { 0 }));
+                    Ok(())
+                }
+                _ => Err(CompileError::new("invalid literal representation")),
+            },
             Expression::Variable(var) => {
                 let wasm_name = self.lookup_binding(&var.name)?;
                 self.push_line(&format!("local.get {}", wasm_name));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,8 @@
 use crate::ast::*;
 use crate::error::CompileError;
-use crate::lexer::{Token, TokenKind};
+use crate::lexer::{
+    FloatLiteralSuffix as LexerFloatSuffix, IntLiteralSuffix as LexerIntSuffix, Token, TokenKind,
+};
 use crate::span::Span;
 
 pub struct Parser<'a> {
@@ -365,17 +367,29 @@ impl<'a> Parser<'a> {
     fn parse_primary(&mut self) -> Result<Expression, CompileError> {
         let token = self.current().clone();
         match &token.kind {
-            TokenKind::IntLiteral(value) => {
+            TokenKind::IntLiteral { value, suffix } => {
                 self.advance();
                 Ok(Expression::Literal(Literal {
-                    value: LiteralValue::Int(*value),
+                    value: LiteralValue::Int(IntLiteral {
+                        value: *value,
+                        suffix: suffix.map(|s| match s {
+                            LexerIntSuffix::I32 => IntSuffix::I32,
+                            LexerIntSuffix::I64 => IntSuffix::I64,
+                        }),
+                    }),
                     span: token.span,
                 }))
             }
-            TokenKind::FloatLiteral(value) => {
+            TokenKind::FloatLiteral { value, suffix } => {
                 self.advance();
                 Ok(Expression::Literal(Literal {
-                    value: LiteralValue::Float(*value),
+                    value: LiteralValue::Float(FloatLiteral {
+                        value: *value,
+                        suffix: suffix.map(|s| match s {
+                            LexerFloatSuffix::F32 => FloatSuffix::F32,
+                            LexerFloatSuffix::F64 => FloatSuffix::F64,
+                        }),
+                    }),
                     span: token.span,
                 }))
             }

--- a/tests/numerics.rs
+++ b/tests/numerics.rs
@@ -1,0 +1,72 @@
+use bootstrap::compile;
+use wasmi::{Engine, Func, Linker, Module, Store, TypedFunc, Value};
+
+#[test]
+fn numeric_suffixes_emit_correct_types() {
+    let source = r#"
+fn add_wide(a: i64, b: i64) -> i64 {
+    a + b + 1i64
+}
+
+fn sum_f32() -> f32 {
+    let mut total: f32 = 1.5;
+    total = total + 2.25;
+    total
+}
+
+fn sum_f64() -> f64 {
+    let mut total: f64 = 1.0f64;
+    total = total + 2.5f64;
+    total
+}
+
+fn main() -> i64 {
+    add_wide(10i64, 5i64)
+}
+"#;
+
+    let compilation = compile(source).expect("failed to compile source");
+    let wasm = compilation.to_wasm().expect("failed to encode wasm");
+
+    let engine = Engine::default();
+    let mut wasm_reader = wasm.as_slice();
+    let module = Module::new(&engine, &mut wasm_reader).expect("failed to create module");
+    let mut store = Store::new(&engine, ());
+    let linker = Linker::new(&engine);
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .expect("failed to instantiate module")
+        .start(&mut store)
+        .expect("failed to start module");
+
+    let main_func: TypedFunc<(), i64> = instance
+        .get_typed_func(&mut store, "main")
+        .expect("expected exported main");
+    let sum_f32_func: Func = instance
+        .get_func(&mut store, "sum_f32")
+        .expect("expected exported sum_f32");
+    let sum_f64_func: Func = instance
+        .get_func(&mut store, "sum_f64")
+        .expect("expected exported sum_f64");
+
+    let main_result = main_func
+        .call(&mut store, ())
+        .expect("failed to execute main");
+    assert_eq!(main_result, 16);
+
+    let mut f32_results = [Value::F32(0.0f32.into())];
+    sum_f32_func
+        .call(&mut store, &[], &mut f32_results)
+        .expect("failed to execute sum_f32");
+    let f32_value = f32_results[0].f32().expect("expected f32 result").to_bits();
+    let f32_result = f32::from_bits(f32_value);
+    assert!((f32_result - 3.75).abs() < f32::EPSILON);
+
+    let mut f64_results = [Value::F64(0.0f64.into())];
+    sum_f64_func
+        .call(&mut store, &[], &mut f64_results)
+        .expect("failed to execute sum_f64");
+    let f64_value = f64_results[0].f64().expect("expected f64 result").to_bits();
+    let f64_result = f64::from_bits(f64_value);
+    assert!((f64_result - 3.5).abs() < 1e-9);
+}


### PR DESCRIPTION
## Summary
- allow integer and float literals to carry explicit i32/i64 and f32/f64 suffixes and validate suffix usage during lexing
- thread literal suffix information through the parser, type checker, and code generators so i64/f64 constants emit correct instructions
- add a numeric integration test that executes i64, f32, and f64 functions via wasmi

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dde0f146e48329a42b1889bd2ef490