### PR TITLE
Support parenthesized expressions

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -98,6 +98,7 @@ pub enum Expression {
     Binary(BinaryExpr),
     Unary(UnaryExpr),
     Call(CallExpr),
+    Group(GroupExpr),
     If(IfExpr),
     Block(Block),
     Loop(LoopExpr),
@@ -193,6 +194,12 @@ pub struct CallExpr {
 }
 
 #[derive(Debug, Clone)]
+pub struct GroupExpr {
+    pub expr: Box<Expression>,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone)]
 pub struct IfExpr {
     pub condition: Box<Expression>,
     pub then_branch: Block,
@@ -221,6 +228,7 @@ impl Expression {
             Expression::Binary(expr) => expr.span,
             Expression::Unary(expr) => expr.span,
             Expression::Call(call) => call.span,
+            Expression::Group(group) => group.span,
             Expression::If(if_expr) => if_expr.span,
             Expression::Block(block) => block.span,
             Expression::Loop(loop_expr) => loop_expr.span,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -414,6 +414,19 @@ impl<'a> Parser<'a> {
                     span: token.span,
                 }))
             }
+            TokenKind::LParen => {
+                let lparen = self.advance();
+                let expr = self.parse_expression()?;
+                let rparen = self.expect(
+                    |k| matches!(k, TokenKind::RParen),
+                    "expected ')' to close expression",
+                )?;
+                let span = Span::new(lparen.span.start, rparen.span.end);
+                Ok(Expression::Group(GroupExpr {
+                    expr: Box::new(expr),
+                    span,
+                }))
+            }
             TokenKind::If => self.parse_if_expression(),
             TokenKind::Loop => self.parse_loop_expression(),
             TokenKind::While => self.parse_while_expression(),

--- a/src/typeck.rs
+++ b/src/typeck.rs
@@ -341,6 +341,7 @@ impl TypeChecker {
             AstExpression::Binary(bin) => self.check_binary(bin),
             AstExpression::Unary(un) => self.check_unary(un),
             AstExpression::Call(call) => self.check_call(call),
+            AstExpression::Group(group) => self.check_expression(*group.expr),
             AstExpression::If(if_expr) => self.check_if(if_expr),
             AstExpression::Block(block) => {
                 let block = self.check_block(block)?;

--- a/tests/grouping.rs
+++ b/tests/grouping.rs
@@ -1,0 +1,46 @@
+use bootstrap::compile;
+use wasmi::{Engine, Linker, Module, Store, TypedFunc};
+
+#[test]
+fn parenthesized_expressions_evaluate_correctly() {
+    let source = r#"
+fn compute() -> i32 {
+    let base: i32 = 2;
+    (base + 3) * (4 + 1)
+}
+
+fn bool_gate(flag: bool) -> i32 {
+    if (flag && (false || true)) {
+        1
+    } else {
+        0
+    }
+}
+
+fn main() -> i32 {
+    (compute() / (3 - 1)) + bool_gate(true)
+}
+"#;
+
+    let compilation = compile(source).expect("failed to compile source");
+    let wasm = compilation.to_wasm().expect("failed to encode wasm");
+
+    let engine = Engine::default();
+    let mut wasm_reader = wasm.as_slice();
+    let module = Module::new(&engine, &mut wasm_reader).expect("failed to create module");
+    let mut store = Store::new(&engine, ());
+    let linker = Linker::new(&engine);
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .expect("failed to instantiate module")
+        .start(&mut store)
+        .expect("failed to start module");
+
+    let main: TypedFunc<(), i32> = instance
+        .get_typed_func(&mut store, "main")
+        .expect("expected exported main");
+
+    let result = main.call(&mut store, ()).expect("failed to execute main");
+
+    assert_eq!(result, 13);
+}


### PR DESCRIPTION
## Summary
- add an AST node for grouped expressions and teach the parser to build it
- update semantic analysis to evaluate the inner expression and ignore the wrapper
- cover the feature with a wasm execution test using parenthesized arithmetic and boolean logic

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ddf156552c8329891ca0409ef19a4d