### PR TITLE
Disallow float remainders in the type checker

### DIFF
--- a/src/typeck.rs
+++ b/src/typeck.rs
@@ -651,11 +651,7 @@ impl TypeChecker {
         span: Span,
     ) -> Result<Type, CompileError> {
         match op {
-            AstBinaryOp::Add
-            | AstBinaryOp::Sub
-            | AstBinaryOp::Mul
-            | AstBinaryOp::Div
-            | AstBinaryOp::Rem => {
+            AstBinaryOp::Add | AstBinaryOp::Sub | AstBinaryOp::Mul | AstBinaryOp::Div => {
                 if left == right && left.is_numeric() {
                     Ok(left)
                 } else {
@@ -664,6 +660,24 @@ impl TypeChecker {
                             .with_span(span),
                     )
                 }
+            }
+            AstBinaryOp::Rem => {
+                if left != right {
+                    return Err(CompileError::new(format!(
+                        "remainder operands must share type, found `{}` and `{}`",
+                        self.format_type(left),
+                        self.format_type(right)
+                    ))
+                    .with_span(span));
+                }
+                if !left.is_integer() {
+                    return Err(CompileError::new(format!(
+                        "remainder is only supported for integer types, found `{}`",
+                        self.format_type(left)
+                    ))
+                    .with_span(span));
+                }
+                Ok(left)
             }
             AstBinaryOp::Eq | AstBinaryOp::Ne => {
                 if left == right {

--- a/tests/numerics.rs
+++ b/tests/numerics.rs
@@ -70,3 +70,25 @@ fn main() -> i64 {
     let f64_result = f64::from_bits(f64_value);
     assert!((f64_result - 3.5).abs() < 1e-9);
 }
+
+#[test]
+fn float_remainder_is_rejected() {
+    let source = r#"
+fn main() -> f32 {
+    5.0f32 % 2.0f32
+}
+"#;
+
+    let error = match compile(source) {
+        Ok(_) => panic!("expected float remainder to be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(
+        error
+            .message
+            .contains("remainder is only supported for integer types"),
+        "unexpected error message: {}",
+        error.message
+    );
+}


### PR DESCRIPTION
## Summary
- reject non-integer operands for the `%` operator during type checking so the restriction matches wasm codegen
- add a regression test covering the float remainder error message

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68de018416c08329bd455fc3f6e08435