### PR TITLE
Export linear memory from generated Wasm modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ The WAT output defines a Wasm module with exported `add` and `main` functions; t
 binary output contains the corresponding `.wasm` module, and `--run` executes it
 directly with Node.js.
 
+### WebAssembly Interop
+
+Generated modules export a linear memory named `memory` with an initial size of
+one WebAssembly page (64KiB). Hosts can write byte buffers, such as UTF-8
+strings, into this memory and pass their pointer/length pairs to compiled
+functions (for example to model `&[u8]` inputs) while we continue building out
+first-class slice support in the language itself.
+
 ## Supported Language Features
 
 - `fn` definitions with typed parameters and return values (`i32`, `i64`, `f32`, `f64`, `bool`, `()`)

--- a/src/codegen/wasm.rs
+++ b/src/codegen/wasm.rs
@@ -65,8 +65,20 @@ impl WasmGenerator {
         }
         push_section(&mut module, 3, &function_section);
 
+        let mut memory_section = Vec::new();
+        encode_u32(&mut memory_section, 1);
+        memory_section.push(0x00);
+        encode_u32(&mut memory_section, 1);
+        push_section(&mut module, 5, &memory_section);
+
         let mut export_section = Vec::new();
-        encode_u32(&mut export_section, program.functions.len() as u32);
+        encode_u32(
+            &mut export_section,
+            (program.functions.len() + 1) as u32,
+        );
+        encode_name(&mut export_section, "memory");
+        export_section.push(0x02);
+        encode_u32(&mut export_section, 0);
         for (index, function) in program.functions.iter().enumerate() {
             encode_name(&mut export_section, &function.name);
             export_section.push(0x00);

--- a/src/codegen/wat.rs
+++ b/src/codegen/wat.rs
@@ -16,6 +16,7 @@ impl WatGenerator {
     pub fn emit_program(&self, program: &hir::Program) -> Result<String, CompileError> {
         let mut module = String::new();
         module.push_str("(module\n");
+        module.push_str("  (memory (export \"memory\") 1)\n");
 
         let mut function_names = Vec::new();
         for function in &program.functions {

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -1,0 +1,43 @@
+use bootstrap::compile;
+use wasmi::{Engine, Linker, Memory, Module, Store, TypedFunc};
+
+#[test]
+fn exports_single_page_memory() {
+    let source = r#"
+fn main(ptr: i32, len: i32) -> i32 {
+    len
+}
+"#;
+
+    let compilation = compile(source).expect("failed to compile source");
+    let wasm = compilation
+        .to_wasm()
+        .expect("failed to encode module to wasm bytes");
+
+    let engine = Engine::default();
+    let module = Module::new(&engine, wasm.as_slice()).expect("failed to build module");
+    let mut store = Store::new(&engine, ());
+    let linker = Linker::new(&engine);
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .expect("failed to instantiate")
+        .start(&mut store)
+        .expect("failed to start module");
+
+    let memory: Memory = instance
+        .get_memory(&mut store, "memory")
+        .expect("expected exported linear memory");
+    let memory_bytes = memory
+        .current_pages(&store)
+        .to_bytes()
+        .expect("memory size to fit into usize");
+    assert_eq!(memory_bytes, 65536);
+
+    let main: TypedFunc<(i32, i32), i32> = instance
+        .get_typed_func(&mut store, "main")
+        .expect("expected exported main function");
+    let result = main
+        .call(&mut store, (0, 42))
+        .expect("failed to execute main");
+    assert_eq!(result, 42);
+}


### PR DESCRIPTION
## Summary
- export a single-page linear memory from the generated Wasm modules and surface it in the WAT output
- add a regression test that instantiates a compiled module, validates the memory export, and exercises a pointer/length entry point
- document the new memory export so hosts can stage byte buffers (e.g. `&[u8]`) when calling into compiled programs

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68de09b74104832999afb49d26c8afd7