### PR TITLE
Add load_u8 intrinsic for memory-backed string inputs

### DIFF
--- a/src/codegen/wat.rs
+++ b/src/codegen/wat.rs
@@ -256,6 +256,9 @@ impl<'a> FunctionEmitter<'a> {
                 for arg in &call.args {
                     self.emit_expression(arg)?;
                 }
+                if self.emit_intrinsic_call(call)? {
+                    return Ok(());
+                }
                 self.push_line(&format!("call ${}", call.callee));
                 Ok(())
             }
@@ -357,6 +360,21 @@ impl<'a> FunctionEmitter<'a> {
         };
         self.push_line(op);
         Ok(())
+    }
+
+    fn emit_intrinsic_call(&mut self, call: &hir::CallExpr) -> Result<bool, CompileError> {
+        match call.callee.as_str() {
+            "load_u8" => {
+                if call.args.len() != 1 {
+                    return Err(CompileError::new(
+                        "`load_u8` intrinsic expects a single pointer argument",
+                    ));
+                }
+                self.push_line("i32.load8_u");
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
     }
 
     fn emit_logical(&mut self, expr: &hir::BinaryExpr) -> Result<(), CompileError> {

--- a/src/typeck.rs
+++ b/src/typeck.rs
@@ -120,8 +120,17 @@ pub struct TypeChecker {
 
 impl TypeChecker {
     pub fn new() -> Self {
+        let mut functions = HashMap::new();
+        functions.insert(
+            "load_u8".to_string(),
+            FunctionSignature {
+                params: vec![Type::I32],
+                return_type: Type::I32,
+            },
+        );
+
         Self {
-            functions: HashMap::new(),
+            functions,
             scopes: Vec::new(),
             current_return_type: Type::Unit,
             loop_stack: Vec::new(),
@@ -136,6 +145,13 @@ impl TypeChecker {
                 .map(|param| self.type_from_type_expr(&param.ty))
                 .collect::<Result<Vec<_>, _>>()?;
             let return_type = self.type_from_type_expr(&function.return_type)?;
+            if self.functions.contains_key(&function.name) {
+                return Err(CompileError::new(format!(
+                    "function `{}` already defined",
+                    function.name
+                ))
+                .with_span(function.span));
+            }
             self.functions.insert(
                 function.name.clone(),
                 FunctionSignature {


### PR DESCRIPTION
## Summary
- add a `load_u8` intrinsic that allows programs to read bytes from linear memory when targeting Wasm
- prevent user code from redefining builtin functions and teach both the WAT and Wasm generators how to emit the intrinsic
- extend the memory test suite with coverage for reading the final byte of an input slice

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68de0fde666c8329819714898312fdca