### PR TITLE
Extend stage1 compiler expression parsing

### DIFF
--- a/examples/stage1_minimal.bp
+++ b/examples/stage1_minimal.bp
@@ -273,6 +273,148 @@ fn write_constant_module(base: i32, instr_base: i32, instr_len: i32) -> i32 {
     write_code_section(base, offset, instr_base, instr_len)
 }
 
+fn parse_expression(
+    base: i32,
+    len: i32,
+    offset: i32,
+    instr_base: i32,
+    instr_offset_ptr: i32
+) -> i32 {
+    let mut idx: i32 = parse_value(base, len, offset, instr_base, instr_offset_ptr);
+    if idx < 0 {
+        return -1;
+    };
+
+    loop {
+        idx = skip_whitespace(base, len, idx);
+        if idx >= len {
+            break;
+        };
+
+        let op_byte: i32 = peek_byte(base, len, idx);
+        if op_byte == 43 || op_byte == 45 {
+            idx = idx + 1;
+            let next_idx: i32 =
+                parse_value(base, len, idx, instr_base, instr_offset_ptr);
+            if next_idx < 0 {
+                return -1;
+            };
+            idx = next_idx;
+
+            let mut instr_offset: i32 = load_i32(instr_offset_ptr);
+            if op_byte == 43 {
+                instr_offset = emit_add(instr_base, instr_offset);
+            } else {
+                instr_offset = emit_sub(instr_base, instr_offset);
+            };
+            store_i32(instr_offset_ptr, instr_offset);
+            continue;
+        };
+
+        if op_byte == 41 || op_byte == 59 || op_byte == 125 {
+            break;
+        };
+
+        return -1;
+    };
+
+    idx
+}
+
+fn parse_value(
+    base: i32,
+    len: i32,
+    offset: i32,
+    instr_base: i32,
+    instr_offset_ptr: i32
+) -> i32 {
+    let mut idx: i32 = skip_whitespace(base, len, offset);
+    if idx >= len {
+        return -1;
+    };
+
+    let mut sign: i32 = 1;
+    loop {
+        if idx >= len {
+            return -1;
+        };
+        let byte: i32 = peek_byte(base, len, idx);
+        if byte == 45 {
+            sign = sign * -1;
+            idx = idx + 1;
+        } else if byte == 43 {
+            idx = idx + 1;
+        } else {
+            break;
+        };
+        idx = skip_whitespace(base, len, idx);
+    };
+
+    if idx >= len {
+        return -1;
+    };
+
+    let head_byte: i32 = peek_byte(base, len, idx);
+    if head_byte == 40 {
+        idx = idx + 1;
+        if sign == -1 {
+            let mut instr_offset: i32 = load_i32(instr_offset_ptr);
+            instr_offset = emit_i32_const(instr_base, instr_offset, 0);
+            store_i32(instr_offset_ptr, instr_offset);
+        };
+        let inner_idx: i32 =
+            parse_expression(base, len, idx, instr_base, instr_offset_ptr);
+        if inner_idx < 0 {
+            return -1;
+        };
+        idx = skip_whitespace(base, len, inner_idx);
+        idx = expect_char(base, len, idx, 41);
+        if idx < 0 {
+            return -1;
+        };
+        if sign == -1 {
+            let mut instr_offset: i32 = load_i32(instr_offset_ptr);
+            instr_offset = emit_sub(instr_base, instr_offset);
+            store_i32(instr_offset_ptr, instr_offset);
+        };
+        return idx;
+    };
+
+    if head_byte < 48 || head_byte > 57 {
+        return -1;
+    };
+
+    let mut value: i32 = 0;
+    let mut has_digit: bool = false;
+    loop {
+        if idx >= len {
+            break;
+        };
+        let digit_byte: i32 = peek_byte(base, len, idx);
+        if digit_byte < 48 || digit_byte > 57 {
+            break;
+        };
+        let digit: i32 = digit_byte - 48;
+        value = value * 10 + digit;
+        has_digit = true;
+        idx = idx + 1;
+    };
+
+    if !has_digit {
+        return -1;
+    };
+
+    if sign == -1 {
+        value = 0 - value;
+    };
+
+    let mut instr_offset: i32 = load_i32(instr_offset_ptr);
+    instr_offset = emit_i32_const(instr_base, instr_offset, value);
+    store_i32(instr_offset_ptr, instr_offset);
+
+    idx
+}
+
 fn compile(input_ptr: i32, input_len: i32, out_ptr: i32) -> i32 {
     if input_len == 0 {
         return -1;
@@ -393,119 +535,21 @@ fn compile(input_ptr: i32, input_len: i32, out_ptr: i32) -> i32 {
     };
 
     let instr_base: i32 = out_ptr + 8192;
-    let mut instr_offset: i32 = 0;
+    let instr_offset_ptr: i32 = out_ptr + 4096;
+    store_i32(instr_offset_ptr, 0);
 
-    if offset >= input_len {
+    offset = parse_expression(
+        input_ptr,
+        input_len,
+        offset,
+        instr_base,
+        instr_offset_ptr
+    );
+    if offset < 0 {
         return -1;
     };
 
-    let mut sign: i32 = 1;
-    let mut current_byte: i32 = peek_byte(input_ptr, input_len, offset);
-    if current_byte == 45 {
-        sign = -1;
-        offset = offset + 1;
-        if offset >= input_len {
-            return -1;
-        };
-        current_byte = peek_byte(input_ptr, input_len, offset);
-    } else if current_byte == 43 {
-        offset = offset + 1;
-        if offset >= input_len {
-            return -1;
-        };
-        current_byte = peek_byte(input_ptr, input_len, offset);
-    };
-
-    let mut has_digit: bool = false;
-    let mut value: i32 = 0;
-    loop {
-        if offset >= input_len {
-            break;
-        };
-        let digit_byte: i32 = peek_byte(input_ptr, input_len, offset);
-        if digit_byte < 48 || digit_byte > 57 {
-            break;
-        };
-        let digit: i32 = digit_byte - 48;
-        value = value * 10 + digit;
-        has_digit = true;
-        offset = offset + 1;
-    };
-
-    if !has_digit {
-        return -1;
-    };
-
-    if sign == -1 {
-        value = 0 - value;
-    };
-
-    instr_offset = emit_i32_const(instr_base, instr_offset, value);
-
-    loop {
-        offset = skip_whitespace(input_ptr, input_len, offset);
-        if offset >= input_len {
-            break;
-        };
-        let op_byte: i32 = peek_byte(input_ptr, input_len, offset);
-        if op_byte != 43 && op_byte != 45 {
-            break;
-        };
-        offset = offset + 1;
-        offset = skip_whitespace(input_ptr, input_len, offset);
-
-        if offset >= input_len {
-            return -1;
-        };
-
-        let mut next_sign: i32 = 1;
-        let mut next_byte: i32 = peek_byte(input_ptr, input_len, offset);
-        if next_byte == 45 {
-            next_sign = -1;
-            offset = offset + 1;
-            if offset >= input_len {
-                return -1;
-            };
-            next_byte = peek_byte(input_ptr, input_len, offset);
-        } else if next_byte == 43 {
-            offset = offset + 1;
-            if offset >= input_len {
-                return -1;
-            };
-            next_byte = peek_byte(input_ptr, input_len, offset);
-        };
-
-        let mut next_has_digit: bool = false;
-        let mut next_value: i32 = 0;
-        loop {
-            if offset >= input_len {
-                break;
-            };
-            let digit_byte: i32 = peek_byte(input_ptr, input_len, offset);
-            if digit_byte < 48 || digit_byte > 57 {
-                break;
-            };
-            let digit: i32 = digit_byte - 48;
-            next_value = next_value * 10 + digit;
-            next_has_digit = true;
-            offset = offset + 1;
-        };
-
-        if !next_has_digit {
-            return -1;
-        };
-
-        if next_sign == -1 {
-            next_value = 0 - next_value;
-        };
-
-        instr_offset = emit_i32_const(instr_base, instr_offset, next_value);
-        if op_byte == 43 {
-            instr_offset = emit_add(instr_base, instr_offset);
-        } else {
-            instr_offset = emit_sub(instr_base, instr_offset);
-        };
-    };
+    let mut instr_offset: i32 = load_i32(instr_offset_ptr);
 
     offset = skip_whitespace(input_ptr, input_len, offset);
 


### PR DESCRIPTION
## Summary
- add recursive `parse_expression`/`parse_value` helpers to the stage1 compiler so it can compile parenthesized and unary arithmetic
- track the instruction write cursor via memory so the new helpers can emit Wasm as they parse and simplify `compile`
- expand the stage1 integration test with a program that exercises nested parentheses and unary negation

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68de2a1a8ea483298f0a5e34ff566157