### PR TITLE
Increase wasm memory and add bootstrap harness

### DIFF
--- a/examples/stage1_minimal.bp
+++ b/examples/stage1_minimal.bp
@@ -673,7 +673,7 @@ fn write_memory_section(base: i32, offset: i32) -> i32 {
     out = write_u32_leb(base, out, 3);
     out = write_u32_leb(base, out, 1);
     out = write_u32_leb(base, out, 0);
-    out = write_u32_leb(base, out, 2);
+    out = write_u32_leb(base, out, 4);
     out
 }
 

--- a/src/codegen/wasm.rs
+++ b/src/codegen/wasm.rs
@@ -68,7 +68,7 @@ impl WasmGenerator {
         let mut memory_section = Vec::new();
         encode_u32(&mut memory_section, 1);
         memory_section.push(0x00);
-        encode_u32(&mut memory_section, 2);
+        encode_u32(&mut memory_section, 4);
         push_section(&mut module, 5, &memory_section);
 
         let mut export_section = Vec::new();

--- a/src/codegen/wat.rs
+++ b/src/codegen/wat.rs
@@ -16,7 +16,7 @@ impl WatGenerator {
     pub fn emit_program(&self, program: &hir::Program) -> Result<String, CompileError> {
         let mut module = String::new();
         module.push_str("(module\n");
-        module.push_str("  (memory (export \"memory\") 1)\n");
+        module.push_str("  (memory (export \"memory\") 4)\n");
 
         let mut function_names = Vec::new();
         for function in &program.functions {

--- a/tests/bootstrap_stage1.rs
+++ b/tests/bootstrap_stage1.rs
@@ -1,67 +1,11 @@
 use std::fs;
 
 use bootstrap::compile;
-use wasmi::{Engine, Linker, Memory, Module, Store, TypedFunc};
 
-fn stage1_compile_program(
-    store: &mut Store<()>,
-    memory: &Memory,
-    compile_func: &TypedFunc<(i32, i32, i32), i32>,
-    input_cursor: &mut usize,
-    output_cursor: &mut i32,
-    source: &str,
-) -> Vec<u8> {
-    memory
-        .write(&mut *store, *input_cursor, source.as_bytes())
-        .expect("failed to write source for stage1");
+#[path = "wasm_harness.rs"]
+mod wasm_harness;
 
-    let produced_len = compile_func
-        .call(
-            &mut *store,
-            (*input_cursor as i32, source.len() as i32, *output_cursor),
-        )
-        .expect("stage1 compile invocation failed");
-    assert!(produced_len > 0, "stage1 compiler returned no bytes");
-
-    let mut output = vec![0u8; produced_len as usize];
-    memory
-        .read(&*store, *output_cursor as usize, &mut output)
-        .expect("failed to read stage1 output");
-
-    *input_cursor += 256;
-    *output_cursor += 4096;
-
-    output
-}
-
-fn run_stage1_output(engine: &Engine, wasm: &[u8]) -> i32 {
-    let target_module = Module::new(engine, wasm).expect("failed to create target module");
-    let mut target_store = Store::new(engine, ());
-    let target_linker = Linker::new(engine);
-    let target_instance = target_linker
-        .instantiate(&mut target_store, &target_module)
-        .expect("failed to instantiate target module")
-        .start(&mut target_store)
-        .expect("failed to start target module");
-
-    let target_memory: Memory = target_instance
-        .get_memory(&mut target_store, "memory")
-        .expect("compiled module should export memory");
-    assert_eq!(
-        target_memory
-            .current_pages(&target_store)
-            .to_bytes()
-            .expect("memory pages to bytes"),
-        131072
-    );
-
-    let main_fn: TypedFunc<(), i32> = target_instance
-        .get_typed_func(&mut target_store, "main")
-        .expect("compiled module should export main");
-    main_fn
-        .call(&mut target_store, ())
-        .expect("failed to execute compiled main")
-}
+use wasm_harness::{run_wasm_main, CompilerInstance};
 
 #[test]
 fn stage1_constant_compiler_emits_wasm() {
@@ -73,166 +17,136 @@ fn stage1_constant_compiler_emits_wasm() {
         .to_wasm()
         .expect("failed to encode stage1 wasm");
 
-    let engine = Engine::default();
-    let module =
-        Module::new(&engine, stage1_wasm.as_slice()).expect("failed to create stage1 module");
-    let mut store = Store::new(&engine, ());
-    let linker = Linker::new(&engine);
-    let instance = linker
-        .instantiate(&mut store, &module)
-        .expect("failed to instantiate stage1 module")
-        .start(&mut store)
-        .expect("failed to start stage1 module");
-
-    let memory: Memory = instance
-        .get_memory(&mut store, "memory")
-        .expect("stage1 module must export memory");
+    let mut compiler = CompilerInstance::new(stage1_wasm.as_slice());
+    assert_eq!(compiler.memory_size_bytes(), 262144);
 
     let mut input_cursor = 0usize;
     let mut output_cursor = 1024i32;
 
-    let compile_func: TypedFunc<(i32, i32, i32), i32> = instance
-        .get_typed_func(&mut store, "compile")
-        .expect("expected exported compile function");
-
-    let output = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 { return 7; }",
-    );
+    let output = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 { return 7; }",
+        )
+        .expect("stage1 should compile constant return");
     assert!(output.starts_with(&[0x00, 0x61, 0x73, 0x6d]));
-    assert_eq!(run_stage1_output(&engine, &output), 7);
+    assert_eq!(run_wasm_main(compiler.engine(), &output), 7);
 
-    let output_two = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    -9\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_two), -9);
+    let output_two = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    -9\n}\n",
+        )
+        .expect("stage1 should compile negative literal");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_two), -9);
 
-    let output_three = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    return 5 + 3 - 2 + -4;\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_three), 2);
+    let output_three = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    return 5 + 3 - 2 + -4;\n}\n",
+        )
+        .expect("stage1 should compile arithmetic chain");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_three), 2);
 
-    let output_four = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    return -(1 + 2) + (3 - (4 - 5));\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_four), 1);
+    let output_four = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    return -(1 + 2) + (3 - (4 - 5));\n}\n",
+        )
+        .expect("stage1 should compile nested expressions");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_four), 1);
 
-    let output_five = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    return 6 * 7;\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_five), 42);
+    let output_five = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    return 6 * 7;\n}\n",
+        )
+        .expect("stage1 should compile multiplication");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_five), 42);
 
-    let output_six = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    return 30 / 2 + 4 * 3;\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_six), 27);
+    let output_six = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    return 30 / 2 + 4 * 3;\n}\n",
+        )
+        .expect("stage1 should compile mixed ops");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_six), 27);
 
-    let output_seven = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    let x: i32 = 2 + 3;\n    let y: i32 = x * 10;\n    y / 2\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_seven), 25);
+    let output_seven = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    let x: i32 = 2 + 3;\n    let y: i32 = x * 10;\n    y / 2\n}\n",
+        )
+        .expect("stage1 should compile let binding");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_seven), 25);
 
-    let output_eight = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    let mut total: i32 = 1;\n    total = total + 5;\n    total\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_eight), 6);
+    let output_eight = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    let mut total: i32 = 1;\n    total = total + 5;\n    total\n}\n",
+        )
+        .expect("stage1 should compile mut assignment");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_eight), 6);
 
-    let output_nine = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    let mut value: i32 = 1;\n    let cond: bool = 2 + 2 == 4 && !(3 < 2);\n    if cond {\n        value = value + 4;\n    };\n    if 10 <= 5 || cond {\n        value = value + 8;\n    };\n    value\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_nine), 13);
+    let output_nine = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    let mut value: i32 = 1;\n    let cond: bool = 2 + 2 == 4 && !(3 < 2);\n    if cond {\n        value = value + 4;\n    };\n    if 10 <= 5 || cond {\n        value = value + 8;\n    };\n    value\n}\n",
+        )
+        .expect("stage1 should compile boolean logic");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_nine), 13);
 
-    let output_ten = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    let cond: bool = 3 > 5;\n    let computed: i32 = if cond {\n        1\n    } else {\n        let base: i32 = 2;\n        base * 5\n    };\n    let chained: i32 = if cond {\n        10\n    } else if true {\n        20\n    } else {\n        30\n    };\n    computed + chained\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_ten), 30);
+    let output_ten = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    let cond: bool = 3 > 5;\n    let computed: i32 = if cond {\n        1\n    } else {\n        let base: i32 = 2;\n        base * 5\n    };\n    let chained: i32 = if cond {\n        10\n    } else if true {\n        20\n    } else {\n        30\n    };\n    computed + chained\n}\n",
+        )
+        .expect("stage1 should compile nested if expressions");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_ten), 30);
 
-    let output_eleven = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    let mut acc: i32 = 0;\n    let mut i: i32 = 0;\n    loop {\n        if i == 5 {\n            break;\n        };\n        acc = acc + i;\n        i = i + 1;\n    };\n    acc\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_eleven), 10);
+    let output_eleven = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    let mut acc: i32 = 0;\n    let mut i: i32 = 0;\n    loop {\n        if i == 5 {\n            break;\n        };\n        acc = acc + i;\n        i = i + 1;\n    };\n    acc\n}\n",
+        )
+        .expect("stage1 should compile loop with break");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_eleven), 10);
 
-    let output_twelve = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn main() -> i32 {\n    let mut total: i32 = 0;\n    let mut i: i32 = 0;\n    loop {\n        i = i + 1;\n        if i > 6 {\n            break;\n        };\n        let parity: i32 = i - (i / 2) * 2;\n        if parity == 1 {\n            continue;\n        };\n        total = total + i;\n    };\n    total\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_twelve), 12);
+    let output_twelve = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn main() -> i32 {\n    let mut total: i32 = 0;\n    let mut i: i32 = 0;\n    loop {\n        i = i + 1;\n        if i > 6 {\n            break;\n        };\n        let parity: i32 = i - (i / 2) * 2;\n        if parity == 1 {\n            continue;\n        };\n        total = total + i;\n    };\n    total\n}\n",
+        )
+        .expect("stage1 should compile loop with continue");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_twelve), 12);
 
-    let output_thirteen = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn helper() -> i32 {\n    return 5;\n}\n\nfn main() -> i32 {\n    helper()\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_thirteen), 5);
+    let output_thirteen = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn helper() -> i32 {\n    return 5;\n}\n\nfn main() -> i32 {\n    helper()\n}\n",
+        )
+        .expect("stage1 should compile simple call");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_thirteen), 5);
 
-    let output_fourteen = stage1_compile_program(
-        &mut store,
-        &memory,
-        &compile_func,
-        &mut input_cursor,
-        &mut output_cursor,
-        "fn increment(value: i32) -> i32 {\n    value + 1\n}\n\nfn is_even(value: i32) -> bool {\n    return value - (value / 2) * 2 == 0;\n}\n\nfn pick(flag: bool, left: i32, right: i32) -> i32 {\n    if flag {\n        left\n    } else {\n        right\n    }\n}\n\nfn main() -> i32 {\n    let base: i32 = increment(7);\n    pick(is_even(base), base, 5)\n}\n",
-    );
-    assert_eq!(run_stage1_output(&engine, &output_fourteen), 8);
+    let output_fourteen = compiler
+        .compile_with_layout(
+            &mut input_cursor,
+            &mut output_cursor,
+            "fn increment(value: i32) -> i32 {\n    value + 1\n}\n\nfn is_even(value: i32) -> bool {\n    return value - (value / 2) * 2 == 0;\n}\n\nfn pick(flag: bool, left: i32, right: i32) -> i32 {\n    if flag {\n        left\n    } else {\n        right\n    }\n}\n\nfn main() -> i32 {\n    let base: i32 = increment(7);\n    pick(is_even(base), base, 5)\n}\n",
+        )
+        .expect("stage1 should compile multi-function program");
+    assert_eq!(run_wasm_main(compiler.engine(), &output_fourteen), 8);
 }

--- a/tests/bootstrap_stage2.rs
+++ b/tests/bootstrap_stage2.rs
@@ -1,0 +1,50 @@
+use std::fs;
+
+use bootstrap::compile;
+use bootstrap::lexer::Lexer;
+use bootstrap::parser::Parser;
+
+#[path = "wasm_harness.rs"]
+mod wasm_harness;
+
+use wasm_harness::{CompileFailure, CompilerInstance};
+
+#[test]
+fn stage1_compiler_identifies_forward_reference_blocker() {
+    let stage1_source =
+        fs::read_to_string("examples/stage1_minimal.bp").expect("failed to load stage1 source");
+
+    let stage1_compilation = compile(&stage1_source).expect("failed to compile stage1 source");
+    let stage1_wasm = stage1_compilation
+        .to_wasm()
+        .expect("failed to encode stage1 wasm");
+
+    let mut stage1 = CompilerInstance::new(stage1_wasm.as_slice());
+
+    // Compile the stage1 source with the stage1 compiler itself to produce stage2.
+    let result = stage1.compile_at(0, 131072, &stage1_source);
+    match result {
+        Ok(_) => panic!("stage1 unexpectedly compiled itself without resolving forward references"),
+        Err(CompileFailure {
+            produced_len,
+            functions,
+            instr_offset,
+        }) => {
+            assert_eq!(produced_len, -1);
+            assert_eq!(instr_offset, 0);
+
+            let tokens = Lexer::new(&stage1_source)
+                .collect::<Result<Vec<_>, _>>()
+                .expect("lex stage1 source");
+            let mut parser = Parser::new(&tokens, &stage1_source);
+            let program = parser.parse_program().expect("parse stage1 source");
+            let total_functions = program.functions.len() as i32;
+
+            assert!(functions > 0, "expected to register at least one function");
+            assert!(
+                functions < total_functions,
+                "expected failure before all functions were processed"
+            );
+        }
+    }
+}

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -35,7 +35,7 @@ fn main() -> i32 {
         .current_pages(&store)
         .to_bytes()
         .expect("memory size to fit into usize");
-    assert_eq!(memory_bytes, 131072);
+    assert_eq!(memory_bytes, 262144);
 
     let slice_len: TypedFunc<(i32, i32), i32> = instance
         .get_typed_func(&mut store, "slice_len")

--- a/tests/wasm_harness.rs
+++ b/tests/wasm_harness.rs
@@ -1,0 +1,177 @@
+#![allow(dead_code)]
+
+use wasmi::{Engine, Linker, Memory, Module, Store, TypedFunc};
+
+pub const DEFAULT_INPUT_STRIDE: usize = 256;
+pub const DEFAULT_OUTPUT_STRIDE: i32 = 4096;
+
+pub struct CompilerInstance {
+    engine: Engine,
+    store: Store<()>,
+    memory: Memory,
+    compile: TypedFunc<(i32, i32, i32), i32>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CompileFailure {
+    pub produced_len: i32,
+    pub functions: i32,
+    pub instr_offset: i32,
+}
+
+impl CompilerInstance {
+    pub fn new(wasm: &[u8]) -> Self {
+        let engine = Engine::default();
+        Self::from_engine(engine, wasm)
+    }
+
+    fn from_engine(engine: Engine, wasm: &[u8]) -> Self {
+        let module = Module::new(&engine, wasm).expect("failed to create module");
+        let mut store = Store::new(&engine, ());
+        let linker = Linker::new(&engine);
+        let instance = linker
+            .instantiate(&mut store, &module)
+            .expect("failed to instantiate module")
+            .start(&mut store)
+            .expect("failed to start module");
+        let memory = instance
+            .get_memory(&mut store, "memory")
+            .expect("compiler module must export memory");
+        let compile = instance
+            .get_typed_func(&mut store, "compile")
+            .expect("expected exported compile function");
+
+        Self {
+            engine,
+            store,
+            memory,
+            compile,
+        }
+    }
+
+    pub fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
+    pub fn memory_size_bytes(&self) -> usize {
+        self
+            .memory
+            .current_pages(&self.store)
+            .to_bytes()
+            .expect("memory pages to bytes") as usize
+    }
+
+    pub fn compile_at(
+        &mut self,
+        input_ptr: usize,
+        output_ptr: i32,
+        source: &str,
+    ) -> Result<Vec<u8>, CompileFailure> {
+        assert!(output_ptr >= 0, "output pointer must be non-negative");
+        assert!(
+            input_ptr <= i32::MAX as usize,
+            "input pointer must fit in i32"
+        );
+        assert!(
+            source.len() <= i32::MAX as usize,
+            "source length must fit in i32"
+        );
+
+        self
+            .memory
+            .write(&mut self.store, input_ptr, source.as_bytes())
+            .expect("failed to write source into compiler memory");
+
+        let produced_len = self
+            .compile
+            .call(
+                &mut self.store,
+                (input_ptr as i32, source.len() as i32, output_ptr),
+            )
+            .expect("compiler invocation failed");
+        if produced_len <= 0 {
+            let mut func_buf = [0u8; 4];
+            let mut instr_buf = [0u8; 4];
+            let func_ptr = output_ptr as usize + 40952;
+            let instr_ptr = output_ptr as usize + 4096;
+            let _ = self
+                .memory
+                .read(&self.store, func_ptr, &mut func_buf);
+            let _ = self
+                .memory
+                .read(&self.store, instr_ptr, &mut instr_buf);
+            let functions = i32::from_le_bytes(func_buf);
+            let instr_offset = i32::from_le_bytes(instr_buf);
+            return Err(CompileFailure {
+                produced_len,
+                functions,
+                instr_offset,
+            });
+        }
+
+        let mut output = vec![0u8; produced_len as usize];
+        self
+            .memory
+            .read(&self.store, output_ptr as usize, &mut output)
+            .expect("failed to read compiler output");
+        Ok(output)
+    }
+
+    pub fn compile_with_stride(
+        &mut self,
+        input_cursor: &mut usize,
+        output_cursor: &mut i32,
+        input_stride: usize,
+        output_stride: i32,
+        source: &str,
+    ) -> Result<Vec<u8>, CompileFailure> {
+        let output = self.compile_at(*input_cursor, *output_cursor, source)?;
+        *input_cursor += input_stride;
+        *output_cursor += output_stride;
+        Ok(output)
+    }
+
+    pub fn compile_with_layout(
+        &mut self,
+        input_cursor: &mut usize,
+        output_cursor: &mut i32,
+        source: &str,
+    ) -> Result<Vec<u8>, CompileFailure> {
+        self.compile_with_stride(
+            input_cursor,
+            output_cursor,
+            DEFAULT_INPUT_STRIDE,
+            DEFAULT_OUTPUT_STRIDE,
+            source,
+        )
+    }
+}
+
+pub fn run_wasm_main(engine: &Engine, wasm: &[u8]) -> i32 {
+    let module = Module::new(engine, wasm).expect("failed to create target module");
+    let mut store = Store::new(engine, ());
+    let linker = Linker::new(engine);
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .expect("failed to instantiate target module")
+        .start(&mut store)
+        .expect("failed to start target module");
+
+    let memory: Memory = instance
+        .get_memory(&mut store, "memory")
+        .expect("compiled module should export memory");
+    assert_eq!(
+        memory
+            .current_pages(&store)
+            .to_bytes()
+            .expect("memory pages to bytes"),
+        262144
+    );
+
+    let main_fn: TypedFunc<(), i32> = instance
+        .get_typed_func(&mut store, "main")
+        .expect("compiled module should export main");
+    main_fn
+        .call(&mut store, ())
+        .expect("failed to execute compiled main")
+}


### PR DESCRIPTION
## Summary
- export four WebAssembly pages from both code generators and stage1_minimal to give the bootstrap compiler more working room
- introduce a reusable Wasmi harness for integration tests and simplify the stage1 test around it
- add a stage2 regression test that documents the remaining forward-reference blocker and update the memory test expectations

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68deb9ad471c8329ac1755554cb93c29