### PR TITLE
Allow trailing commas in params and calls

### DIFF
--- a/examples/stage1_minimal.bp
+++ b/examples/stage1_minimal.bp
@@ -3207,7 +3207,17 @@ fn compile(input_ptr: i32, input_len: i32, out_ptr: i32) -> i32 {
             };
             let delimiter: i32 = peek_byte(input_ptr, input_len, param_parse_idx);
             if delimiter == 44 {
-                param_parse_idx = skip_whitespace(input_ptr, input_len, param_parse_idx + 1);
+                let mut after_comma: i32 =
+                    skip_whitespace(input_ptr, input_len, param_parse_idx + 1);
+                if after_comma >= input_len {
+                    return -1;
+                };
+                let next_token: i32 = peek_byte(input_ptr, input_len, after_comma);
+                if next_token == 41 {
+                    param_parse_idx = after_comma + 1;
+                    break;
+                };
+                param_parse_idx = after_comma;
                 continue;
             };
             if delimiter == 41 {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -87,6 +87,9 @@ impl<'a> Parser<'a> {
 
             if self.current_is(|k| matches!(k, TokenKind::Comma)) {
                 self.advance();
+                if self.current_is(|k| matches!(k, TokenKind::RParen)) {
+                    break;
+                }
             } else {
                 break;
             }
@@ -355,6 +358,9 @@ impl<'a> Parser<'a> {
                         args.push(arg);
                         if self.current_is(|k| matches!(k, TokenKind::Comma)) {
                             self.advance();
+                            if self.current_is(|k| matches!(k, TokenKind::RParen)) {
+                                break;
+                            }
                         } else {
                             break;
                         }

--- a/tests/trailing_commas.rs
+++ b/tests/trailing_commas.rs
@@ -1,0 +1,84 @@
+use std::fs;
+
+use bootstrap::compile;
+use wasmi::{Engine, Linker, Module, Store, TypedFunc};
+
+#[path = "wasm_harness.rs"]
+mod wasm_harness;
+
+use wasm_harness::{run_wasm_main, CompilerInstance};
+
+#[test]
+fn trailing_commas_in_params_and_calls_are_accepted() {
+    let source = r#"
+fn add(
+    a: i32,
+    b: i32,
+) -> i32 {
+    a + b
+}
+
+fn main() -> i32 {
+    add(1, 2,)
+}
+"#;
+
+    let compilation = compile(source).expect("failed to compile source");
+    let wasm = compilation.to_wasm().expect("failed to encode wasm");
+
+    let engine = Engine::default();
+    let mut wasm_reader = wasm.as_slice();
+    let module = Module::new(&engine, &mut wasm_reader).expect("failed to create module");
+    let mut store = Store::new(&engine, ());
+    let linker = Linker::new(&engine);
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .expect("failed to instantiate module")
+        .start(&mut store)
+        .expect("failed to start module");
+
+    let main: TypedFunc<(), i32> = instance
+        .get_typed_func(&mut store, "main")
+        .expect("expected exported main");
+
+    let result = main.call(&mut store, ()).expect("failed to execute main");
+
+    assert_eq!(result, 3);
+}
+
+#[test]
+fn stage1_compiler_accepts_trailing_commas() {
+    let stage1_source =
+        fs::read_to_string("examples/stage1_minimal.bp").expect("failed to load stage1 source");
+
+    let stage1_compilation = compile(&stage1_source).expect("failed to compile stage1 source");
+    let stage1_wasm = stage1_compilation
+        .to_wasm()
+        .expect("failed to encode stage1 wasm");
+
+    let mut compiler = CompilerInstance::new(stage1_wasm.as_slice());
+
+    let mut input_cursor = 0usize;
+    let mut output_cursor = 1024i32;
+
+    let program = r#"
+fn add(
+    a: i32,
+    b: i32,
+) -> i32 {
+    a + b
+}
+
+fn main() -> i32 {
+    add(1, 2,)
+}
+"#;
+
+    let output = compiler
+        .compile_with_layout(&mut input_cursor, &mut output_cursor, program)
+        .expect("stage1 should compile trailing comma program");
+
+    let result = run_wasm_main(compiler.engine(), &output);
+
+    assert_eq!(result, 3);
+}


### PR DESCRIPTION
## Summary
- accept trailing commas in function parameter lists and call argument lists
- add an integration test covering trailing commas in both declarations and invocations
- update the stage1 bootstrap compiler to allow trailing commas in parameter lists and verify with a stage1 test

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68dee9df0e6483299dafea8637eefcda