### PR TITLE
Fix stage1 parsing of tightly spaced return expressions

### DIFF
--- a/examples/stage1_minimal.bp
+++ b/examples/stage1_minimal.bp
@@ -1779,7 +1779,7 @@ fn parse_return_statement(
     };
     if idx < len {
         let after_byte: i32 = peek_byte(base, len, idx);
-        if !is_whitespace(after_byte) {
+        if is_identifier_continue(after_byte) {
             return -1;
         };
     };


### PR DESCRIPTION
## Summary
- relax the stage1 parser so `return` only rejects identifier continuations, allowing expressions like `return-1`
- add a regression test ensuring the stage1 wasm compiler accepts tightly spaced return expressions

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68def05eb8888329b25cd3437904b342