### PR TITLE
Enable stage1 mismatched assignment test

### DIFF
--- a/tests/bootstrap_stage1.rs
+++ b/tests/bootstrap_stage1.rs
@@ -297,7 +297,6 @@ fn main() -> i32 {
 }
 
 #[test]
-#[ignore = "stage1_minimal currently allows reassigning locals with values of a different type"]
 fn stage1_compiler_rejects_assigning_mismatched_types() {
     let source = fs::read_to_string("examples/stage1_minimal.bp")
         .expect("failed to load stage1 source");


### PR DESCRIPTION
## Summary
- enable the stage1 compiler regression test that rejects mismatched-type assignments

## Testing
- cargo test stage1_compiler_rejects_assigning_mismatched_types

------
https://chatgpt.com/codex/tasks/task_e_68df103355d083299bb014c2e877ab4c