### PR TITLE
Allow stage1 compiler to handle `return;` statements

### DIFF
--- a/examples/stage1_minimal.bp
+++ b/examples/stage1_minimal.bp
@@ -2512,28 +2512,46 @@ fn parse_return_statement(
         };
     };
     idx = skip_whitespace(base, len, idx);
-    let saved_condition_instr: i32 = load_i32(instr_offset_ptr);
-    idx = parse_expression(
-        base,
-        len,
-        idx,
-        instr_base,
-        instr_offset_ptr,
-        locals_base,
-        locals_count_ptr,
-        control_stack_base,
-        control_stack_count_ptr,
-        functions_base,
-        functions_count_ptr,
-        expr_type_ptr
-        );
-    if idx < 0 {
+    if idx >= len {
         return -1;
     };
-    idx = skip_whitespace(base, len, idx);
-    idx = expect_char(base, len, idx, 59);
-    if idx < 0 {
-        return -1;
+    let expected_return: i32 = load_i32(functions_base - 4);
+    let next_byte: i32 = peek_byte(base, len, idx);
+    if next_byte == 59 {
+        if expected_return != type_code_unit() {
+            return -1;
+        };
+        idx = idx + 1;
+    } else {
+        let saved_instr_offset: i32 = load_i32(instr_offset_ptr);
+        idx = parse_expression(
+            base,
+            len,
+            idx,
+            instr_base,
+            instr_offset_ptr,
+            locals_base,
+            locals_count_ptr,
+            control_stack_base,
+            control_stack_count_ptr,
+            functions_base,
+            functions_count_ptr,
+            expr_type_ptr
+            );
+        if idx < 0 {
+            store_i32(instr_offset_ptr, saved_instr_offset);
+            return -1;
+        };
+        if get_expr_type(expr_type_ptr) != expected_return {
+            store_i32(instr_offset_ptr, saved_instr_offset);
+            return -1;
+        };
+        idx = skip_whitespace(base, len, idx);
+        idx = expect_char(base, len, idx, 59);
+        if idx < 0 {
+            store_i32(instr_offset_ptr, saved_instr_offset);
+            return -1;
+        };
     };
 
     let mut instr_offset: i32 = load_i32(instr_offset_ptr);
@@ -4335,6 +4353,8 @@ fn compile(input_ptr: i32, input_len: i32, out_ptr: i32) -> i32 {
     let control_stack_base: i32 = out_ptr + 16388;
     let functions_count_ptr: i32 = out_ptr + 40952;
     let functions_base: i32 = out_ptr + 40960;
+    let current_return_type_ptr: i32 = functions_base - 4;
+    store_i32(current_return_type_ptr, type_code_unit());
     store_i32(functions_count_ptr, 0);
 
     let main_index: i32 = register_function_signatures(
@@ -4608,6 +4628,8 @@ fn compile(input_ptr: i32, input_len: i32, out_ptr: i32) -> i32 {
                 return -1;
             };
         };
+
+        store_i32(current_return_type_ptr, expected_return);
 
         if offset < input_len {
             let after_type: i32 = peek_byte(input_ptr, input_len, offset);

--- a/tests/bootstrap_stage2.rs
+++ b/tests/bootstrap_stage2.rs
@@ -46,8 +46,8 @@ fn stage1_compiler_identifies_remaining_bootstrap_blocker() {
                 "stage1 should advance code generation before failing"
             );
             assert_eq!(
-                compiled_functions, 40,
-                "stage1 currently stops compiling at function index 40 (control_stack_set_type_at_depth)"
+                compiled_functions, 66,
+                "stage1 currently stops compiling at function index 66"
             );
 
             let tokens = Lexer::new(&stage1_source)
@@ -219,7 +219,7 @@ fn main() -> i32 {
 }
 
 #[test]
-fn stage1_compiler_rejects_return_without_value() {
+fn stage1_compiler_accepts_return_without_value() {
     let (mut stage1, _) = prepare_stage1_compiler();
 
     let source = r#"
@@ -237,10 +237,9 @@ fn main() -> i32 {
 
     compile(source).expect("host compiler should accept explicit unit returns");
 
-    assert!(
-        stage1.compile_at(0, 131072, source).is_err(),
-        "stage1 still rejects explicit `return;` statements"
-    );
+    stage1
+        .compile_at(0, 131072, source)
+        .expect("stage1 should accept explicit `return;` statements");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- allow the stage1 compiler to accept unit `return;` statements by checking the current function's return type
- store the active function return type while compiling so return parsing can validate expressions
- update the stage2 regression tests to expect successful compilation and the new bootstrap blocker index

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68df68aa6d8c8329aa501618216b69f9