### PR TITLE
Support bit shift operators in stage1 minimal

### DIFF
--- a/examples/stage1_minimal.bp
+++ b/examples/stage1_minimal.bp
@@ -91,6 +91,14 @@ fn emit_or(base: i32, offset: i32) -> i32 {
     write_byte(base, offset, 114)
 }
 
+fn emit_shl(base: i32, offset: i32) -> i32 {
+    write_byte(base, offset, 116)
+}
+
+fn emit_shr_s(base: i32, offset: i32) -> i32 {
+    write_byte(base, offset, 117)
+}
+
 fn emit_if(base: i32, offset: i32, block_type: i32) -> i32 {
     let mut out: i32 = write_byte(base, offset, 4);
     out = write_byte(base, out, block_type);
@@ -1690,7 +1698,7 @@ fn parse_comparison(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    let mut idx: i32 = parse_addition(
+    let mut idx: i32 = parse_shift(
         base,
         len,
         offset,
@@ -1722,17 +1730,35 @@ fn parse_comparison(
         let mut instr_kind: i32 = 0;
 
         if op_byte == 60 {
-            if idx + 1 < len && peek_byte(base, len, idx + 1) == 61 {
-                consumed = 2;
-                instr_kind = 2;
+            if idx + 1 < len {
+                let next: i32 = peek_byte(base, len, idx + 1);
+                if next == 60 {
+                    break;
+                };
+                if next == 61 {
+                    consumed = 2;
+                    instr_kind = 2;
+                } else {
+                    consumed = 1;
+                    instr_kind = 0;
+                };
             } else {
                 consumed = 1;
                 instr_kind = 0;
             };
         } else if op_byte == 62 {
-            if idx + 1 < len && peek_byte(base, len, idx + 1) == 61 {
-                consumed = 2;
-                instr_kind = 3;
+            if idx + 1 < len {
+                let next: i32 = peek_byte(base, len, idx + 1);
+                if next == 62 {
+                    break;
+                };
+                if next == 61 {
+                    consumed = 2;
+                    instr_kind = 3;
+                } else {
+                    consumed = 1;
+                    instr_kind = 1;
+                };
             } else {
                 consumed = 1;
                 instr_kind = 1;
@@ -1752,7 +1778,7 @@ fn parse_comparison(
         };
 
         idx = idx + consumed;
-        let next_idx: i32 = parse_addition(
+        let next_idx: i32 = parse_shift(
             base,
             len,
             idx,
@@ -1789,6 +1815,117 @@ fn parse_comparison(
         store_i32(instr_offset_ptr, instr_offset);
 
         current_type = type_code_bool();
+        set_expr_type(expr_type_ptr, current_type);
+        saw_operator = true;
+    };
+
+    if !saw_operator {
+        set_expr_type(expr_type_ptr, current_type);
+    };
+
+    idx
+}
+
+fn parse_shift(
+    base: i32,
+    len: i32,
+    offset: i32,
+    instr_base: i32,
+    instr_offset_ptr: i32,
+    locals_base: i32,
+    locals_count_ptr: i32,
+    control_stack_base: i32,
+    control_stack_count_ptr: i32,
+    functions_base: i32,
+    functions_count_ptr: i32,
+    expr_type_ptr: i32
+) -> i32 {
+    let mut idx: i32 = parse_addition(
+        base,
+        len,
+        offset,
+        instr_base,
+        instr_offset_ptr,
+        locals_base,
+        locals_count_ptr,
+        control_stack_base,
+        control_stack_count_ptr,
+        functions_base,
+        functions_count_ptr,
+        expr_type_ptr
+        );
+    if idx < 0 {
+        return -1;
+    };
+
+    let mut current_type: i32 = get_expr_type(expr_type_ptr);
+    let mut saw_operator: bool = false;
+
+    loop {
+        idx = skip_whitespace(base, len, idx);
+        if idx >= len {
+            break;
+        };
+
+        if idx + 1 >= len {
+            break;
+        };
+
+        let first: i32 = peek_byte(base, len, idx);
+        let second: i32 = peek_byte(base, len, idx + 1);
+        let mut op_kind: i32 = -1;
+
+        if first == 60 && second == 60 {
+            op_kind = 0;
+        } else if first == 62 && second == 62 {
+            op_kind = 1;
+        } else if first == 41 || first == 59 || first == 125 || first == 123 {
+            break;
+        } else {
+            break;
+        };
+
+        if op_kind < 0 {
+            break;
+        };
+
+        if current_type != type_code_i32() {
+            return -1;
+        };
+
+        idx = idx + 2;
+        let next_idx: i32 = parse_addition(
+            base,
+            len,
+            idx,
+            instr_base,
+            instr_offset_ptr,
+            locals_base,
+            locals_count_ptr,
+            control_stack_base,
+            control_stack_count_ptr,
+            functions_base,
+            functions_count_ptr,
+            expr_type_ptr
+            );
+        if next_idx < 0 {
+            return -1;
+        };
+        idx = next_idx;
+
+        if get_expr_type(expr_type_ptr) != type_code_i32() {
+            return -1;
+        };
+
+        let mut instr_offset: i32 = load_i32(instr_offset_ptr);
+        if op_kind == 0 {
+            instr_offset = emit_shl(instr_base, instr_offset);
+        } else {
+            instr_offset = emit_shr_s(instr_base, instr_offset);
+        };
+        store_i32(instr_offset_ptr, instr_offset);
+
+        current_type = type_code_i32();
         set_expr_type(expr_type_ptr, current_type);
         saw_operator = true;
     };

--- a/tests/bootstrap_stage2.rs
+++ b/tests/bootstrap_stage2.rs
@@ -243,7 +243,7 @@ fn main() -> i32 {
 }
 
 #[test]
-fn stage1_compiler_rejects_bit_shifts() {
+fn stage1_compiler_accepts_bit_shifts() {
     let (mut stage1, _) = prepare_stage1_compiler();
 
     let source = r#"
@@ -255,8 +255,7 @@ fn main() -> i32 {
 
     compile(source).expect("host compiler should accept shift operators");
 
-    assert!(
-        stage1.compile_at(0, 131072, source).is_err(),
-        "stage1 still rejects shift operators"
-    );
+    stage1
+        .compile_at(0, 131072, source)
+        .expect("stage1 should accept shift operators");
 }


### PR DESCRIPTION
## Summary
- add wasm emission helpers for shift instructions in the stage1 minimal compiler
- extend the expression parser to handle << and >> with the correct precedence and update the stage2 bootstrap test

## Testing
- cargo test stage1_compiler_accepts_bit_shifts

------
https://chatgpt.com/codex/tasks/task_e_68df6c91244483299b6ff2fd3caa178b