### PR TITLE
Update stage2 bootstrap blocker test to new failure point

### DIFF
--- a/tests/bootstrap_stage2.rs
+++ b/tests/bootstrap_stage2.rs
@@ -46,8 +46,8 @@ fn stage1_compiler_identifies_remaining_bootstrap_blocker() {
                 "stage1 should advance code generation before failing"
             );
             assert_eq!(
-                compiled_functions, 66,
-                "stage1 currently stops compiling at function index 66"
+                compiled_functions, 84,
+                "stage1 currently stops compiling at function index 84"
             );
 
             let tokens = Lexer::new(&stage1_source)
@@ -62,9 +62,18 @@ fn stage1_compiler_identifies_remaining_bootstrap_blocker() {
                 functions, total_functions,
                 "expected to register all functions"
             );
+
+            let failing_function = &program.functions[compiled_functions as usize];
+            assert_eq!(
+                failing_function.name, "write_type_section",
+                "stage1 now fails while compiling write_type_section (first function containing an else-if chain)"
+            );
         }
     }
 }
+
+// When stage1 fails we report the first function that still needs code generation
+// support in order to reach full stage2 bootstrapping.
 
 #[test]
 fn stage1_compiler_accepts_break_with_value_statements() {


### PR DESCRIPTION
## Summary
- update the stage2 bootstrap test to expect compilation to stop at function index 84
- assert that write_type_section is the first uncompiled function to spotlight the current blocker

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68df6de2f8e48329a7a959b1fa9023dd