### PR TITLE
Add target selection interface for compilation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 
 # TODO
 
-- [ ] **Add target selection for CPU vs GPU compilation**
+- [x] **Add target selection for CPU vs GPU compilation**
   The concept expects both WebAssembly and WGSL backends, but the current public API only emits Wasm and the CLI exposes no way to choose other targets. Introducing a `Target` enum and a `--target` flag would set the stage for a GPU path while continuing to default to Wasm.
   *Reference:* Concept target list【F:concept.md†L3-L14】, current Wasm-only API and CLI【F:src/lib.rs†L13-L97】【F:src/main.rs†L85-L197】
 

--- a/tests/stage1_helpers.rs
+++ b/tests/stage1_helpers.rs
@@ -3,7 +3,7 @@
 use std::fs;
 use std::sync::OnceLock;
 
-use bootstrap::compile;
+use bootstrap::{Target, compile};
 
 #[path = "wasm_harness.rs"]
 mod wasm_harness;
@@ -27,7 +27,7 @@ pub fn stage1_source() -> &'static str {
 pub fn stage1_wasm() -> &'static [u8] {
     STAGE1_WASM
         .get_or_init(|| {
-            compile(stage1_source())
+            compile(stage1_source(), Target::Wasm)
                 .and_then(|compilation| compilation.into_wasm())
                 .unwrap_or_else(|err| panic!("failed to compile stage1 source: {err}"))
         })


### PR DESCRIPTION
## Summary
- introduce a `Target` enum in the library and require callers to select a backend during compilation
- extend the CLI with a `--target` flag and related validation so users can choose wasm or the stubbed wgsl path
- update helpers and TODO tracking to use the new API and mark the target-selection task complete

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e0471193e08329882b197b1eb4818e