### PR TITLE
Centralize stage1 scratch layout constants

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -16,6 +16,7 @@
   The parser in stage1 inlines keyword matching, delimiter handling, and whitespace skipping at every call site, making the 5k+ line file hard to follow and extend. Extracting reusable helpers for repeated loops (parameter lists, return types, block scanning) would shrink the `compile` pipeline and clarify control flow.
   *Reference:* Repeated ad-hoc parsing logic inside `compile`【F:compiler/stage1.bp†L4560-L4662】
 
-- [ ] **Centralize stage1 memory layout constants**
+- [x] **Centralize stage1 memory layout constants**
   The `compile` routine hand-computes offsets like `out_ptr + 4096` and `instr_base + instr_capacity - 12` each time, obscuring the intent of the scratch buffer layout. Introducing named constants or a small struct to manage these regions would make the code self-documenting and reduce arithmetic mistakes when the layout changes.
   *Reference:* Hard-coded scratch buffer offsets in `compile`【F:compiler/stage1.bp†L4665-L4679】
+  *Status:* Introduced helper functions encapsulating scratch buffer offsets and capacities so `compile` no longer performs manual offset arithmetic.

--- a/compiler/stage1.bp
+++ b/compiler/stage1.bp
@@ -41,6 +41,86 @@ fn emit_local_set(base: i32, offset: i32, index: i32) -> i32 {
     out
 }
 
+fn word_size() -> i32 {
+    4
+}
+
+fn scratch_instr_offset() -> i32 {
+    4096
+}
+
+fn scratch_expr_type_offset() -> i32 {
+    4092
+}
+
+fn scratch_instr_base_offset() -> i32 {
+    8192
+}
+
+fn scratch_instr_capacity() -> i32 {
+    65536
+}
+
+fn scratch_locals_capacity() -> i32 {
+    4096
+}
+
+fn scratch_locals_metadata_size() -> i32 {
+    12
+}
+
+fn scratch_functions_count_offset() -> i32 {
+    851960
+}
+
+fn scratch_functions_base_offset() -> i32 {
+    851968
+}
+
+fn scratch_instr_offset_ptr(out_ptr: i32) -> i32 {
+    out_ptr + scratch_instr_offset()
+}
+
+fn scratch_expr_type_ptr(out_ptr: i32) -> i32 {
+    out_ptr + scratch_expr_type_offset()
+}
+
+fn scratch_instr_base(out_ptr: i32) -> i32 {
+    out_ptr + scratch_instr_base_offset()
+}
+
+fn scratch_locals_max_ptr(instr_base: i32) -> i32 {
+    instr_base + scratch_instr_capacity() - scratch_locals_metadata_size()
+}
+
+fn scratch_locals_count_ptr(instr_base: i32) -> i32 {
+    scratch_locals_max_ptr(instr_base) + word_size()
+}
+
+fn scratch_locals_base(instr_base: i32) -> i32 {
+    instr_base + scratch_instr_capacity()
+}
+
+fn scratch_control_stack_count_ptr(instr_base: i32) -> i32 {
+    scratch_locals_base(instr_base) + scratch_locals_capacity()
+}
+
+fn scratch_control_stack_base(instr_base: i32) -> i32 {
+    scratch_control_stack_count_ptr(instr_base) + word_size()
+}
+
+fn scratch_functions_count_ptr(out_ptr: i32) -> i32 {
+    out_ptr + scratch_functions_count_offset()
+}
+
+fn scratch_functions_base(out_ptr: i32) -> i32 {
+    out_ptr + scratch_functions_base_offset()
+}
+
+fn scratch_current_return_type_ptr(out_ptr: i32) -> i32 {
+    scratch_functions_base(out_ptr) - word_size()
+}
+
 fn emit_call(base: i32, offset: i32, index: i32) -> i32 {
     let mut out: i32 = write_byte(base, offset, 16);
     out = write_u32_leb(base, out, index);
@@ -4666,22 +4746,22 @@ fn compile(input_ptr: i32, input_len: i32, out_ptr: i32) -> i32 {
         return -1;
     };
 
-    let instr_offset_ptr: i32 = out_ptr + 4096;
+    let instr_offset_ptr: i32 = scratch_instr_offset_ptr(out_ptr);
     store_i32(instr_offset_ptr, 0);
-    let instr_base: i32 = out_ptr + 8192;
-    let expr_type_ptr: i32 = out_ptr + 4092;
+    let instr_base: i32 = scratch_instr_base(out_ptr);
+    let expr_type_ptr: i32 = scratch_expr_type_ptr(out_ptr);
     store_i32(expr_type_ptr, -1);
-    let instr_capacity: i32 = 65536;
-    let locals_capacity: i32 = 4096;
-    let locals_max_ptr: i32 = instr_base + instr_capacity - 12;
+    let instr_capacity: i32 = scratch_instr_capacity();
+    let locals_capacity: i32 = scratch_locals_capacity();
+    let locals_max_ptr: i32 = scratch_locals_max_ptr(instr_base);
     store_i32(locals_max_ptr, 0);
-    let locals_count_ptr: i32 = instr_base + instr_capacity - 8;
-    let locals_base: i32 = instr_base + instr_capacity;
-    let control_stack_count_ptr: i32 = locals_base + locals_capacity;
-    let control_stack_base: i32 = control_stack_count_ptr + 4;
-    let functions_count_ptr: i32 = out_ptr + 851960;
-    let functions_base: i32 = out_ptr + 851968;
-    let current_return_type_ptr: i32 = functions_base - 4;
+    let locals_count_ptr: i32 = scratch_locals_count_ptr(instr_base);
+    let locals_base: i32 = scratch_locals_base(instr_base);
+    let control_stack_count_ptr: i32 = scratch_control_stack_count_ptr(instr_base);
+    let control_stack_base: i32 = scratch_control_stack_base(instr_base);
+    let functions_count_ptr: i32 = scratch_functions_count_ptr(out_ptr);
+    let functions_base: i32 = scratch_functions_base(out_ptr);
+    let current_return_type_ptr: i32 = scratch_current_return_type_ptr(out_ptr);
     store_i32(current_return_type_ptr, type_code_unit());
     store_i32(functions_count_ptr, 0);
 


### PR DESCRIPTION
## Summary
- add helper functions to express stage1 scratch buffer offsets and capacities
- update the compile routine to use the named helpers instead of hard-coded arithmetic
- mark the todo item for centralizing memory layout constants as complete with a short status note

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e04f6012348329b9737d89f37e45ae