### PR TITLE
Parse type aliases in stage1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,10 @@
   The concept specifies that string constants should become local byte arrays, but stage1 currently lacks any parsing for quoted literals. Teaching the tokenizer and expression lowering to recognize strings and materialize them as `u8` arrays would align the implementation with the design.
   *Reference:* String constant rule【F:concept.md†L31-L31】, absence of string literal handling in stage1 (no quoted literal parsing)【258989†L1-L2】
 
-- [ ] **Parse and register `type` definitions in stage1**
+- [x] **Parse and register `type` definitions in stage1**
   Treating types as constant values requires a place to declare them, but the stage1 compiler presently scans only `fn` items. Allowing `type` aliases (e.g., `type Bytes = Array<u8, N>;`) to be recorded before function compilation would start building the infrastructure for type-level programming without affecting existing codegen.
   *Reference:* Type-as-constant goal【F:concept.md†L10-L13】, function-only parser loop【F:compiler/stage1.bp†L4580-L4619】
+  *Status:* Stage1 now scans `type` aliases before functions, records their source spans in a dedicated table, and verifies the metadata while compiling function bodies.
 
 - [ ] **Factor stage1 parsing into reusable helpers**
   The parser in stage1 inlines keyword matching, delimiter handling, and whitespace skipping at every call site, making the 5k+ line file hard to follow and extend. Extracting reusable helpers for repeated loops (parameter lists, return types, block scanning) would shrink the `compile` pipeline and clarify control flow.

--- a/compiler/stage1.bp
+++ b/compiler/stage1.bp
@@ -77,6 +77,22 @@ fn scratch_functions_base_offset() -> i32 {
     851968
 }
 
+fn type_entry_size() -> i32 {
+    16
+}
+
+fn scratch_types_capacity() -> i32 {
+    2048
+}
+
+fn scratch_types_base_offset() -> i32 {
+    scratch_functions_base_offset() - scratch_types_capacity() * type_entry_size()
+}
+
+fn scratch_types_count_offset() -> i32 {
+    scratch_types_base_offset() - word_size()
+}
+
 fn scratch_instr_offset_ptr(out_ptr: i32) -> i32 {
     out_ptr + scratch_instr_offset()
 }
@@ -115,6 +131,14 @@ fn scratch_functions_count_ptr(out_ptr: i32) -> i32 {
 
 fn scratch_functions_base(out_ptr: i32) -> i32 {
     out_ptr + scratch_functions_base_offset()
+}
+
+fn scratch_types_count_ptr(out_ptr: i32) -> i32 {
+    out_ptr + scratch_types_count_offset()
+}
+
+fn scratch_types_base(out_ptr: i32) -> i32 {
+    out_ptr + scratch_types_base_offset()
 }
 
 fn scratch_current_return_type_ptr(out_ptr: i32) -> i32 {
@@ -780,6 +804,42 @@ fn functions_entry(functions_base: i32, index: i32) -> i32 {
     functions_base + index * 32
 }
 
+fn types_entry(types_base: i32, index: i32) -> i32 {
+    types_base + index * type_entry_size()
+}
+
+fn types_find(
+    source_base: i32,
+    source_len: i32,
+    types_base: i32,
+    types_count_ptr: i32,
+    name_start: i32,
+    name_len: i32,
+) -> i32 {
+    let count: i32 = load_i32(types_count_ptr);
+    let mut idx: i32 = 0;
+    loop {
+        if idx >= count {
+            break;
+        };
+        let entry: i32 = types_entry(types_base, idx);
+        let stored_start: i32 = load_i32(entry);
+        let stored_len: i32 = load_i32(entry + 4);
+        if identifiers_equal(
+            source_base,
+            source_len,
+            stored_start,
+            stored_len,
+            name_start,
+            name_len,
+        ) {
+            return idx;
+        };
+        idx = idx + 1;
+    };
+    -1
+}
+
 fn functions_find(
     source_base: i32,
     source_len: i32,
@@ -949,6 +1009,32 @@ fn expect_keyword_fn(base: i32, len: i32, offset: i32) -> i32 {
     idx = expect_char(base, len, idx, 110);
     if idx < 0 {
         return -1;
+    };
+    idx
+}
+
+fn expect_keyword_type(base: i32, len: i32, offset: i32) -> i32 {
+    let mut idx: i32 = expect_char(base, len, offset, 116);
+    if idx < 0 {
+        return -1;
+    };
+    idx = expect_char(base, len, idx, 121);
+    if idx < 0 {
+        return -1;
+    };
+    idx = expect_char(base, len, idx, 112);
+    if idx < 0 {
+        return -1;
+    };
+    idx = expect_char(base, len, idx, 101);
+    if idx < 0 {
+        return -1;
+    };
+    if idx < len {
+        let next_byte: i32 = peek_byte(base, len, idx);
+        if is_identifier_continue(next_byte) {
+            return -1;
+        };
     };
     idx
 }
@@ -4467,8 +4553,11 @@ fn register_function_signatures(
     input_len: i32,
     functions_base: i32,
     functions_count_ptr: i32,
+    types_base: i32,
+    types_count_ptr: i32,
 ) -> i32 {
     store_i32(functions_count_ptr, 0);
+    store_i32(types_count_ptr, 0);
     let mut offset: i32 = 0;
     let mut main_index: i32 = -1;
 
@@ -4476,6 +4565,130 @@ fn register_function_signatures(
         offset = skip_whitespace(input_ptr, input_len, offset);
         if offset >= input_len {
             break;
+        };
+
+        let mut handled_type: bool = false;
+        if offset + 4 <= input_len {
+            let first_char: i32 = peek_byte(input_ptr, input_len, offset);
+            if first_char == 116 {
+                let second_char: i32 = peek_byte(input_ptr, input_len, offset + 1);
+                let third_char: i32 = peek_byte(input_ptr, input_len, offset + 2);
+                let fourth_char: i32 = peek_byte(input_ptr, input_len, offset + 3);
+                if second_char == 121 && third_char == 112 && fourth_char == 101 {
+                    let after_type: i32 = offset + 4;
+                    if after_type == input_len
+                        || !is_identifier_continue(peek_byte(input_ptr, input_len, after_type))
+                    {
+                        handled_type = true;
+                    };
+                };
+            };
+        };
+        if handled_type {
+            offset = expect_keyword_type(input_ptr, input_len, offset);
+            if offset < 0 {
+                return -1;
+            };
+
+            if offset >= input_len {
+                return -1;
+            };
+            let after_type_byte: i32 = peek_byte(input_ptr, input_len, offset);
+            if after_type_byte < 0 || !is_whitespace(after_type_byte) {
+                return -1;
+            };
+            offset = skip_whitespace(input_ptr, input_len, offset);
+            if offset >= input_len {
+                return -1;
+            };
+
+            let name_start: i32 = offset;
+            let mut name_len: i32 = 0;
+            loop {
+                if offset >= input_len {
+                    break;
+                };
+                let ch: i32 = peek_byte(input_ptr, input_len, offset);
+                if name_len == 0 {
+                    if !is_identifier_start(ch) {
+                        break;
+                    };
+                } else if !is_identifier_continue(ch) {
+                    break;
+                };
+                name_len = name_len + 1;
+                offset = offset + 1;
+            };
+            if name_len == 0 {
+                return -1;
+            };
+
+            if types_find(
+                input_ptr,
+                input_len,
+                types_base,
+                types_count_ptr,
+                name_start,
+                name_len,
+            ) >= 0
+            {
+                return -1;
+            };
+
+            offset = skip_whitespace(input_ptr, input_len, offset);
+            offset = expect_char(input_ptr, input_len, offset, 61);
+            if offset < 0 {
+                return -1;
+            };
+
+            offset = skip_whitespace(input_ptr, input_len, offset);
+            if offset >= input_len {
+                return -1;
+            };
+
+            let value_start: i32 = offset;
+            let mut value_end: i32 = value_start;
+            loop {
+                if value_end >= input_len {
+                    return -1;
+                };
+                let value_byte: i32 = peek_byte(input_ptr, input_len, value_end);
+                if value_byte == 59 {
+                    break;
+                };
+                value_end = value_end + 1;
+            };
+
+            let mut trimmed_end: i32 = value_end;
+            loop {
+                if trimmed_end <= value_start {
+                    break;
+                };
+                let last_byte: i32 = peek_byte(input_ptr, input_len, trimmed_end - 1);
+                if last_byte < 0 {
+                    return -1;
+                };
+                if !is_whitespace(last_byte) {
+                    break;
+                };
+                trimmed_end = trimmed_end - 1;
+            };
+            if trimmed_end <= value_start {
+                return -1;
+            };
+
+            let value_len: i32 = trimmed_end - value_start;
+
+            let type_index: i32 = load_i32(types_count_ptr);
+            let entry: i32 = types_entry(types_base, type_index);
+            store_i32(entry, name_start);
+            store_i32(entry + 4, name_len);
+            store_i32(entry + 8, value_start);
+            store_i32(entry + 12, value_len);
+            store_i32(types_count_ptr, type_index + 1);
+
+            offset = value_end + 1;
+            continue;
         };
 
         offset = expect_keyword_fn(input_ptr, input_len, offset);
@@ -4761,6 +4974,8 @@ fn compile(input_ptr: i32, input_len: i32, out_ptr: i32) -> i32 {
     let control_stack_base: i32 = scratch_control_stack_base(instr_base);
     let functions_count_ptr: i32 = scratch_functions_count_ptr(out_ptr);
     let functions_base: i32 = scratch_functions_base(out_ptr);
+    let types_count_ptr: i32 = scratch_types_count_ptr(out_ptr);
+    let types_base: i32 = scratch_types_base(out_ptr);
     let current_return_type_ptr: i32 = scratch_current_return_type_ptr(out_ptr);
     store_i32(current_return_type_ptr, type_code_unit());
     store_i32(functions_count_ptr, 0);
@@ -4770,6 +4985,8 @@ fn compile(input_ptr: i32, input_len: i32, out_ptr: i32) -> i32 {
         input_len,
         functions_base,
         functions_count_ptr,
+        types_base,
+        types_count_ptr,
     );
     if main_index < 0 {
         return -1;
@@ -4782,11 +4999,133 @@ fn compile(input_ptr: i32, input_len: i32, out_ptr: i32) -> i32 {
 
     let mut offset: i32 = 0;
     let mut compiled_index: i32 = 0;
+    let mut compiled_type_index: i32 = 0;
+    let types_total: i32 = load_i32(types_count_ptr);
 
     loop {
         offset = skip_whitespace(input_ptr, input_len, offset);
         if offset >= input_len {
             break;
+        };
+
+        let mut handled_type: bool = false;
+        if offset + 4 <= input_len {
+            let first_char: i32 = peek_byte(input_ptr, input_len, offset);
+            if first_char == 116 {
+                let second_char: i32 = peek_byte(input_ptr, input_len, offset + 1);
+                let third_char: i32 = peek_byte(input_ptr, input_len, offset + 2);
+                let fourth_char: i32 = peek_byte(input_ptr, input_len, offset + 3);
+                if second_char == 121 && third_char == 112 && fourth_char == 101 {
+                    let after_type: i32 = offset + 4;
+                    if after_type == input_len
+                        || !is_identifier_continue(peek_byte(input_ptr, input_len, after_type))
+                    {
+                        handled_type = true;
+                    };
+                };
+            };
+        };
+        if handled_type {
+            if compiled_type_index >= types_total {
+                return -1;
+            };
+            offset = expect_keyword_type(input_ptr, input_len, offset);
+            if offset < 0 {
+                return -1;
+            };
+
+            if offset >= input_len {
+                return -1;
+            };
+            let after_type_byte: i32 = peek_byte(input_ptr, input_len, offset);
+            if after_type_byte < 0 || !is_whitespace(after_type_byte) {
+                return -1;
+            };
+            offset = skip_whitespace(input_ptr, input_len, offset);
+            if offset >= input_len {
+                return -1;
+            };
+
+            let name_start: i32 = offset;
+            let mut name_len: i32 = 0;
+            loop {
+                if offset >= input_len {
+                    break;
+                };
+                let ch: i32 = peek_byte(input_ptr, input_len, offset);
+                if name_len == 0 {
+                    if !is_identifier_start(ch) {
+                        break;
+                    };
+                } else if !is_identifier_continue(ch) {
+                    break;
+                };
+                name_len = name_len + 1;
+                offset = offset + 1;
+            };
+            if name_len == 0 {
+                return -1;
+            };
+
+            let entry: i32 = types_entry(types_base, compiled_type_index);
+            let stored_name_start: i32 = load_i32(entry);
+            let stored_name_len: i32 = load_i32(entry + 4);
+            if stored_name_start != name_start || stored_name_len != name_len {
+                return -1;
+            };
+
+            offset = skip_whitespace(input_ptr, input_len, offset);
+            offset = expect_char(input_ptr, input_len, offset, 61);
+            if offset < 0 {
+                return -1;
+            };
+
+            offset = skip_whitespace(input_ptr, input_len, offset);
+            if offset >= input_len {
+                return -1;
+            };
+
+            let value_start: i32 = offset;
+            let mut value_end: i32 = value_start;
+            loop {
+                if value_end >= input_len {
+                    return -1;
+                };
+                let value_byte: i32 = peek_byte(input_ptr, input_len, value_end);
+                if value_byte == 59 {
+                    break;
+                };
+                value_end = value_end + 1;
+            };
+
+            let mut trimmed_end: i32 = value_end;
+            loop {
+                if trimmed_end <= value_start {
+                    break;
+                };
+                let last_byte: i32 = peek_byte(input_ptr, input_len, trimmed_end - 1);
+                if last_byte < 0 {
+                    return -1;
+                };
+                if !is_whitespace(last_byte) {
+                    break;
+                };
+                trimmed_end = trimmed_end - 1;
+            };
+            if trimmed_end <= value_start {
+                return -1;
+            };
+
+            let value_len: i32 = trimmed_end - value_start;
+            let stored_value_start: i32 = load_i32(entry + 8);
+            let stored_value_len: i32 = load_i32(entry + 12);
+            if stored_value_start != value_start || stored_value_len != value_len {
+                return -1;
+            };
+
+            offset = value_end + 1;
+            compiled_type_index = compiled_type_index + 1;
+            continue;
         };
 
         offset = expect_keyword_fn(input_ptr, input_len, offset);

--- a/tests/type_definitions.rs
+++ b/tests/type_definitions.rs
@@ -1,0 +1,73 @@
+#[path = "stage1_helpers.rs"]
+mod stage1_helpers;
+
+#[path = "wasm_harness.rs"]
+mod wasm_harness;
+
+use stage1_helpers::{stage1_wasm, try_compile_with_stage1};
+use wasm_harness::{CompilerInstance, DEFAULT_OUTPUT_STRIDE};
+
+fn compile_with_instance(source: &str) -> (CompilerInstance, i32) {
+    let mut compiler = CompilerInstance::new(stage1_wasm());
+    let mut input_cursor = 0usize;
+    let mut output_cursor = 1024i32;
+    compiler
+        .compile_with_layout(&mut input_cursor, &mut output_cursor, source)
+        .expect("stage1 should compile source with type definitions");
+    let output_ptr = output_cursor - DEFAULT_OUTPUT_STRIDE;
+    (compiler, output_ptr)
+}
+
+#[test]
+fn type_definitions_are_registered() {
+    let source = r#"
+        type Count = i32;
+        type Flag = bool ;
+        fn helper() -> i32 {
+            1
+        }
+
+        fn main() -> i32 {
+            helper()
+        }
+    "#;
+
+    let (compiler, output_ptr) = compile_with_instance(source);
+
+    let type_count = compiler.read_types_count(output_ptr);
+    assert_eq!(type_count, 2, "expected two registered type definitions");
+
+    let first = compiler.read_type_entry(output_ptr, 0);
+    let second = compiler.read_type_entry(output_ptr, 1);
+
+    let count_name_start = first.name_start as usize;
+    let count_name_end = count_name_start + first.name_len as usize;
+    assert_eq!(&source[count_name_start..count_name_end], "Count");
+
+    let count_value_start = first.value_start as usize;
+    let count_value_end = count_value_start + first.value_len as usize;
+    assert_eq!(&source[count_value_start..count_value_end], "i32");
+
+    let flag_name_start = second.name_start as usize;
+    let flag_name_end = flag_name_start + second.name_len as usize;
+    assert_eq!(&source[flag_name_start..flag_name_end], "Flag");
+
+    let flag_value_start = second.value_start as usize;
+    let flag_value_end = flag_value_start + second.value_len as usize;
+    assert_eq!(&source[flag_value_start..flag_value_end], "bool");
+}
+
+#[test]
+fn duplicate_type_definitions_are_rejected() {
+    let source = r#"
+        type Count = i32;
+        type Count = bool;
+        fn main() -> i32 {
+            0
+        }
+    "#;
+
+    let error = try_compile_with_stage1(source)
+        .expect_err("duplicate type definitions should be rejected");
+    assert!(error.produced_len <= 0, "compiler should signal failure");
+}


### PR DESCRIPTION
## Summary
- add scratch storage and parsing for `type` aliases when scanning stage1 sources
- ensure the compile loop validates stored type definitions and expose their metadata via the wasm harness
- add regression tests covering recorded type definitions and duplicate alias rejection, and mark the todo item complete

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e0519fc43c8329bb7de556b5cc215d