### PR TITLE
Update compiler cleanup roadmap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,15 +8,18 @@
   The concept specifies that string constants should become local byte arrays, but stage1 currently lacks any parsing for quoted literals. Teaching the tokenizer and expression lowering to recognize strings and materialize them as `u8` arrays would align the implementation with the design.
   *Reference:* String constant rule【F:concept.md†L31-L31】, absence of string literal handling in stage1 (no quoted literal parsing)【258989†L1-L2】
 
-- [x] **Factor stage1 parsing into reusable helpers**
-  The parser in stage1 inlines keyword matching, delimiter handling, and whitespace skipping at every call site, making the 5k+ line file hard to follow and extend. Extracting reusable helpers for repeated loops (parameter lists, return types, block scanning) would shrink the `compile` pipeline and clarify control flow.
-  *Reference:* Repeated ad-hoc parsing logic inside `compile`【F:compiler/stage1.bp†L4560-L4662】
-  *Status:* Added dedicated helpers for parameter lists and optional return types so both signature registration and body compilation share the same parsing routines, removing duplicated loops and keyword handling.
-
 - [ ] **Introduce `SourceCursor` helpers for stage1 parser**
   Stage1 threads the `base`, `len`, and index triplet through nearly every parsing function, reapplying whitespace skipping and byte peeks manually. Creating a lightweight cursor struct with methods for advancing, peeking, and matching delimiters would reduce parameter lists and make control flow clearer.
   *Reference:* Parsing functions repeatedly pass `base`, `len`, and `idx` while chaining `skip_whitespace` and `expect_char` calls【F:compiler/stage1.bp†L4520-L4547】
 
-- [x] **Centralize keyword recognition logic**
-  Detecting `type` and other keywords currently performs ad-hoc byte comparisons for each character before dispatching, leading to verbose and error-prone control flow. Providing a shared helper that validates reserved words and their boundaries would simplify loops that scan items during registration.
-  *Reference:* Manual `type` keyword detection compares individual bytes before calling `expect_keyword_type`【F:compiler/stage1.bp†L4564-L4598】
+- [ ] **Adopt `ParserContext` to bundle mutable parser state**
+  Most stage1 routines pass `scope`, `arena`, and diagnostic sinks separately, cluttering signatures and increasing the chance of mismatched lifetimes. Wrapping these in a lightweight context struct with scoped accessors would clarify ownership and improve testability.
+  *Reference:* Parser functions accept multiple loosely related parameters【F:compiler/stage1.bp†L4488-L4520】
+
+- [ ] **Standardize diagnostic emission helpers**
+  Error reporting interleaves message formatting with control flow, leading to inconsistent phrasing and missed context. Introducing shared helpers for span creation and message templating would keep compiler errors uniform while shrinking the amount of inline glue code.
+  *Reference:* Manual diagnostic construction during signature parsing and type checking【F:compiler/stage1.bp†L4700-L4765】
+
+- [ ] **Layer intermediate AST passes between parsing and lowering**
+  Stage1 currently lowers directly from tokens to bytecode, which tangles syntax handling with code generation details. Introducing a lightweight AST normalization pass would isolate grammar concerns, simplify transformations, and make the compiler easier to reason about.
+  *Reference:* Direct lowering from parser into bytecode emission routines【F:compiler/stage1.bp†L5000-L5180】


### PR DESCRIPTION
## Summary
- remove completed compiler cleanup tasks from the TODO list
- add new items that focus on reorganizing parser state, diagnostics, and intermediate representations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e05afbf7ec8329b32a0238bdd8fe94