### PR TITLE
Introduce initial AST pass for simple expressions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,3 +24,4 @@
 - [ ] **Layer intermediate AST passes between parsing and lowering**
   Stage1 currently lowers directly from tokens to bytecode, which tangles syntax handling with code generation details. Introducing a lightweight AST normalization pass would isolate grammar concerns, simplify transformations, and make the compiler easier to reason about.
   *Reference:* Direct lowering from parser into bytecode emission routines【F:compiler/stage1.bp†L5000-L5180】
+  *Status:* Added scratch-backed AST storage with helpers for constructing simple arithmetic expression trees, plus a wrapper parser that lowers those AST nodes before falling back to the legacy lowering path. This establishes the infrastructure for future passes while preserving existing behavior for unsupported constructs.【F:compiler/stage1.bp†L153-L524】【F:compiler/stage1.bp†L2051-L2232】

--- a/compiler/stage1.bp
+++ b/compiler/stage1.bp
@@ -153,6 +153,524 @@ fn scratch_source_cursor_ptr(out_ptr: i32) -> i32 {
     out_ptr + scratch_source_cursor_offset()
 }
 
+fn scratch_ast_root_offset() -> i32 {
+    scratch_source_cursor_offset() - word_size()
+}
+
+fn scratch_ast_offset_offset() -> i32 {
+    scratch_ast_root_offset() - word_size()
+}
+
+fn scratch_ast_capacity() -> i32 {
+    2048
+}
+
+fn scratch_ast_base_offset() -> i32 {
+    scratch_ast_offset_offset() - scratch_ast_capacity()
+}
+
+fn scratch_out_ptr_from_instr_base(instr_base: i32) -> i32 {
+    instr_base - scratch_instr_base_offset()
+}
+
+fn scratch_ast_root_ptr_from_instr_base(instr_base: i32) -> i32 {
+    let out_ptr: i32 = scratch_out_ptr_from_instr_base(instr_base);
+    out_ptr + scratch_ast_root_offset()
+}
+
+fn scratch_ast_offset_ptr_from_instr_base(instr_base: i32) -> i32 {
+    let out_ptr: i32 = scratch_out_ptr_from_instr_base(instr_base);
+    out_ptr + scratch_ast_offset_offset()
+}
+
+fn scratch_ast_base(instr_base: i32) -> i32 {
+    let out_ptr: i32 = scratch_out_ptr_from_instr_base(instr_base);
+    out_ptr + scratch_ast_base_offset()
+}
+
+fn ast_node_size() -> i32 {
+    16
+}
+
+fn ast_kind_invalid() -> i32 {
+    0
+}
+
+fn ast_kind_i32_const() -> i32 {
+    1
+}
+
+fn ast_kind_local_get() -> i32 {
+    2
+}
+
+fn ast_kind_binary_add() -> i32 {
+    3
+}
+
+fn ast_kind_binary_sub() -> i32 {
+    4
+}
+
+fn ast_kind_binary_mul() -> i32 {
+    5
+}
+
+fn ast_kind_binary_div() -> i32 {
+    6
+}
+
+fn ast_kind_unary_neg() -> i32 {
+    7
+}
+
+fn ast_reset(instr_base: i32) {
+    let ast_offset_ptr: i32 = scratch_ast_offset_ptr_from_instr_base(instr_base);
+    let ast_root_ptr: i32 = scratch_ast_root_ptr_from_instr_base(instr_base);
+    store_i32(ast_offset_ptr, 0);
+    store_i32(ast_root_ptr, -1);
+}
+
+fn ast_allocate_node(ast_base: i32, ast_offset_ptr: i32, kind: i32) -> i32 {
+    let offset: i32 = load_i32(ast_offset_ptr);
+    if offset + ast_node_size() > scratch_ast_capacity() {
+        return -1;
+    };
+    let node_ptr: i32 = ast_base + offset;
+    store_i32(ast_offset_ptr, offset + ast_node_size());
+    store_i32(node_ptr, kind);
+    store_i32(node_ptr + 4, 0);
+    store_i32(node_ptr + 8, 0);
+    store_i32(node_ptr + 12, 0);
+    node_ptr
+}
+
+fn ast_make_i32_const(ast_base: i32, ast_offset_ptr: i32, value: i32) -> i32 {
+    let node_ptr: i32 = ast_allocate_node(ast_base, ast_offset_ptr, ast_kind_i32_const());
+    if node_ptr < 0 {
+        return -1;
+    };
+    store_i32(node_ptr + 4, value);
+    node_ptr
+}
+
+fn ast_make_local_get(ast_base: i32, ast_offset_ptr: i32, wasm_index: i32) -> i32 {
+    let node_ptr: i32 = ast_allocate_node(ast_base, ast_offset_ptr, ast_kind_local_get());
+    if node_ptr < 0 {
+        return -1;
+    };
+    store_i32(node_ptr + 4, wasm_index);
+    node_ptr
+}
+
+fn ast_make_binary(ast_base: i32, ast_offset_ptr: i32, kind: i32, left: i32, right: i32) -> i32 {
+    let node_ptr: i32 = ast_allocate_node(ast_base, ast_offset_ptr, kind);
+    if node_ptr < 0 {
+        return -1;
+    };
+    store_i32(node_ptr + 4, left);
+    store_i32(node_ptr + 8, right);
+    node_ptr
+}
+
+fn ast_make_unary(ast_base: i32, ast_offset_ptr: i32, kind: i32, operand: i32) -> i32 {
+    let node_ptr: i32 = ast_allocate_node(ast_base, ast_offset_ptr, kind);
+    if node_ptr < 0 {
+        return -1;
+    };
+    store_i32(node_ptr + 4, operand);
+    node_ptr
+}
+
+fn parse_simple_primary_ast(
+    base: i32,
+    len: i32,
+    offset: i32,
+    locals_base: i32,
+    locals_count_ptr: i32,
+    ast_base: i32,
+    ast_offset_ptr: i32,
+    node_out_ptr: i32,
+) -> i32 {
+    let mut idx: i32 = skip_whitespace(base, len, offset);
+    if idx >= len {
+        return -3;
+    };
+
+    let head_byte: i32 = peek_byte(base, len, idx);
+    if head_byte == 40 {
+        idx = idx + 1;
+        idx = parse_simple_addition_ast(
+            base,
+            len,
+            idx,
+            locals_base,
+            locals_count_ptr,
+            ast_base,
+            ast_offset_ptr,
+            node_out_ptr,
+        );
+        if idx < 0 {
+            return idx;
+        };
+        idx = skip_whitespace(base, len, idx);
+        idx = expect_char(base, len, idx, 41);
+        if idx < 0 {
+            return -3;
+        };
+        return idx;
+    };
+
+    if head_byte >= 48 && head_byte <= 57 {
+        let mut value: i32 = 0;
+        let mut has_digit: bool = false;
+        loop {
+            if idx >= len {
+                break;
+            };
+            let digit_byte: i32 = peek_byte(base, len, idx);
+            if digit_byte < 48 || digit_byte > 57 {
+                break;
+            };
+            let digit: i32 = digit_byte - 48;
+            value = value * 10 + digit;
+            has_digit = true;
+            idx = idx + 1;
+        };
+        if !has_digit {
+            return -3;
+        };
+        let node_ptr: i32 = ast_make_i32_const(ast_base, ast_offset_ptr, value);
+        if node_ptr < 0 {
+            return -3;
+        };
+        store_i32(node_out_ptr, node_ptr);
+        return idx;
+    };
+
+    if !is_identifier_start(head_byte) {
+        return -3;
+    };
+
+    let ident_start: i32 = idx;
+    let mut ident_len: i32 = 0;
+    loop {
+        if idx >= len {
+            break;
+        };
+        let ch: i32 = peek_byte(base, len, idx);
+        if ident_len == 0 {
+            if !is_identifier_start(ch) {
+                break;
+            };
+        } else if !is_identifier_continue(ch) {
+            break;
+        };
+        ident_len = ident_len + 1;
+        idx = idx + 1;
+    };
+    if ident_len == 0 {
+        return -3;
+    };
+
+    let after_ident: i32 = skip_whitespace(base, len, idx);
+    if after_ident < len {
+        let next_byte: i32 = peek_byte(base, len, after_ident);
+        if next_byte == 40 {
+            return -3;
+        };
+    };
+
+    let entry_index: i32 = locals_find(
+        base,
+        len,
+        locals_base,
+        locals_count_ptr,
+        ident_start,
+        ident_len,
+    );
+    if entry_index < 0 {
+        return -3;
+    };
+    let var_type: i32 = locals_entry_type(locals_base, entry_index);
+    if var_type != type_code_i32() {
+        return -3;
+    };
+    let wasm_index: i32 = locals_entry_wasm_index(locals_base, entry_index);
+    let node_ptr: i32 = ast_make_local_get(ast_base, ast_offset_ptr, wasm_index);
+    if node_ptr < 0 {
+        return -3;
+    };
+    store_i32(node_out_ptr, node_ptr);
+    idx
+}
+
+fn parse_simple_unary_ast(
+    base: i32,
+    len: i32,
+    offset: i32,
+    locals_base: i32,
+    locals_count_ptr: i32,
+    ast_base: i32,
+    ast_offset_ptr: i32,
+    node_out_ptr: i32,
+) -> i32 {
+    let mut idx: i32 = skip_whitespace(base, len, offset);
+    let mut negate_count: i32 = 0;
+    loop {
+        if idx >= len {
+            break;
+        };
+        let ch: i32 = peek_byte(base, len, idx);
+        if ch == 45 {
+            negate_count = negate_count + 1;
+            idx = idx + 1;
+            continue;
+        };
+        if ch == 43 {
+            idx = idx + 1;
+            continue;
+        };
+        break;
+    };
+
+    idx = parse_simple_primary_ast(
+        base,
+        len,
+        idx,
+        locals_base,
+        locals_count_ptr,
+        ast_base,
+        ast_offset_ptr,
+        node_out_ptr,
+    );
+    if idx < 0 {
+        return idx;
+    };
+
+    if (negate_count & 1) != 0 {
+        let operand: i32 = load_i32(node_out_ptr);
+        let node_ptr: i32 = ast_make_unary(ast_base, ast_offset_ptr, ast_kind_unary_neg(), operand);
+        if node_ptr < 0 {
+            return -3;
+        };
+        store_i32(node_out_ptr, node_ptr);
+    };
+
+    idx
+}
+
+fn parse_simple_multiplication_ast(
+    base: i32,
+    len: i32,
+    offset: i32,
+    locals_base: i32,
+    locals_count_ptr: i32,
+    ast_base: i32,
+    ast_offset_ptr: i32,
+    node_out_ptr: i32,
+) -> i32 {
+    let mut idx: i32 = parse_simple_unary_ast(
+        base,
+        len,
+        offset,
+        locals_base,
+        locals_count_ptr,
+        ast_base,
+        ast_offset_ptr,
+        node_out_ptr,
+    );
+    if idx < 0 {
+        return idx;
+    };
+
+    let mut current_node: i32 = load_i32(node_out_ptr);
+
+    loop {
+        idx = skip_whitespace(base, len, idx);
+        if idx >= len {
+            break;
+        };
+        let op_byte: i32 = peek_byte(base, len, idx);
+        if op_byte != 42 && op_byte != 47 {
+            break;
+        };
+        idx = idx + 1;
+        idx = parse_simple_unary_ast(
+            base,
+            len,
+            idx,
+            locals_base,
+            locals_count_ptr,
+            ast_base,
+            ast_offset_ptr,
+            node_out_ptr,
+        );
+        if idx < 0 {
+            return idx;
+        };
+        let right_node: i32 = load_i32(node_out_ptr);
+        let node_kind: i32 = if op_byte == 42 { ast_kind_binary_mul() } else { ast_kind_binary_div() };
+        let new_node: i32 = ast_make_binary(ast_base, ast_offset_ptr, node_kind, current_node, right_node);
+        if new_node < 0 {
+            return -3;
+        };
+        current_node = new_node;
+        store_i32(node_out_ptr, current_node);
+    };
+
+    store_i32(node_out_ptr, current_node);
+    idx
+}
+
+fn parse_simple_addition_ast(
+    base: i32,
+    len: i32,
+    offset: i32,
+    locals_base: i32,
+    locals_count_ptr: i32,
+    ast_base: i32,
+    ast_offset_ptr: i32,
+    node_out_ptr: i32,
+) -> i32 {
+    let mut idx: i32 = parse_simple_multiplication_ast(
+        base,
+        len,
+        offset,
+        locals_base,
+        locals_count_ptr,
+        ast_base,
+        ast_offset_ptr,
+        node_out_ptr,
+    );
+    if idx < 0 {
+        return idx;
+    };
+
+    let mut current_node: i32 = load_i32(node_out_ptr);
+
+    loop {
+        idx = skip_whitespace(base, len, idx);
+        if idx >= len {
+            break;
+        };
+        let op_byte: i32 = peek_byte(base, len, idx);
+        if op_byte != 43 && op_byte != 45 {
+            break;
+        };
+        idx = idx + 1;
+        idx = parse_simple_multiplication_ast(
+            base,
+            len,
+            idx,
+            locals_base,
+            locals_count_ptr,
+            ast_base,
+            ast_offset_ptr,
+            node_out_ptr,
+        );
+        if idx < 0 {
+            return idx;
+        };
+        let right_node: i32 = load_i32(node_out_ptr);
+        let node_kind: i32 = if op_byte == 43 { ast_kind_binary_add() } else { ast_kind_binary_sub() };
+        let new_node: i32 = ast_make_binary(ast_base, ast_offset_ptr, node_kind, current_node, right_node);
+        if new_node < 0 {
+            return -3;
+        };
+        current_node = new_node;
+        store_i32(node_out_ptr, current_node);
+    };
+
+    store_i32(node_out_ptr, current_node);
+    idx
+}
+
+fn parse_simple_expression_ast(
+    base: i32,
+    len: i32,
+    offset: i32,
+    locals_base: i32,
+    locals_count_ptr: i32,
+    ast_base: i32,
+    ast_offset_ptr: i32,
+    node_out_ptr: i32,
+) -> i32 {
+    parse_simple_addition_ast(
+        base,
+        len,
+        offset,
+        locals_base,
+        locals_count_ptr,
+        ast_base,
+        ast_offset_ptr,
+        node_out_ptr,
+    )
+}
+
+fn lower_simple_ast_node(
+    ast_base: i32,
+    node_ptr: i32,
+    instr_base: i32,
+    offset: i32,
+) -> i32 {
+    if node_ptr < 0 {
+        return -1;
+    };
+    let kind: i32 = load_i32(node_ptr);
+    if kind == ast_kind_i32_const() {
+        let value: i32 = load_i32(node_ptr + 4);
+        return emit_i32_const(instr_base, offset, value);
+    };
+    if kind == ast_kind_local_get() {
+        let wasm_index: i32 = load_i32(node_ptr + 4);
+        return emit_local_get(instr_base, offset, wasm_index);
+    };
+    if kind == ast_kind_unary_neg() {
+        let operand: i32 = load_i32(node_ptr + 4);
+        let mut next_offset: i32 = emit_i32_const(instr_base, offset, 0);
+        next_offset = lower_simple_ast_node(ast_base, operand, instr_base, next_offset);
+        if next_offset < 0 {
+            return -1;
+        };
+        next_offset = emit_sub(instr_base, next_offset);
+        return next_offset;
+    };
+    if kind == ast_kind_binary_add() || kind == ast_kind_binary_sub() || kind == ast_kind_binary_mul() || kind == ast_kind_binary_div() {
+        let left: i32 = load_i32(node_ptr + 4);
+        let right: i32 = load_i32(node_ptr + 8);
+        let mut next_offset: i32 = lower_simple_ast_node(ast_base, left, instr_base, offset);
+        if next_offset < 0 {
+            return -1;
+        };
+        next_offset = lower_simple_ast_node(ast_base, right, instr_base, next_offset);
+        if next_offset < 0 {
+            return -1;
+        };
+        if kind == ast_kind_binary_add() {
+            return emit_add(instr_base, next_offset);
+        };
+        if kind == ast_kind_binary_sub() {
+            return emit_sub(instr_base, next_offset);
+        };
+        if kind == ast_kind_binary_mul() {
+            return emit_mul(instr_base, next_offset);
+        };
+        return emit_div(instr_base, next_offset);
+    };
+    -1
+}
+
+fn lower_simple_ast(ast_base: i32, root: i32, instr_base: i32, instr_offset_ptr: i32) -> i32 {
+    let offset: i32 = load_i32(instr_offset_ptr);
+    let final_offset: i32 = lower_simple_ast_node(ast_base, root, instr_base, offset);
+    if final_offset < 0 {
+        return -1;
+    };
+    store_i32(instr_offset_ptr, final_offset);
+    0
+}
+
 fn source_cursor_init(cursor_ptr: i32, base: i32, len: i32, offset: i32) {
     store_i32(cursor_ptr, base);
     store_i32(cursor_ptr + 4, len);
@@ -1648,7 +2166,84 @@ fn parse_expression(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    parse_or(
+    let saved_instr_offset: i32 = load_i32(instr_offset_ptr);
+    let ast_offset_ptr: i32 = scratch_ast_offset_ptr_from_instr_base(instr_base);
+    let ast_root_ptr: i32 = scratch_ast_root_ptr_from_instr_base(instr_base);
+    let ast_base: i32 = scratch_ast_base(instr_base);
+    let saved_ast_offset: i32 = load_i32(ast_offset_ptr);
+    let saved_root: i32 = load_i32(ast_root_ptr);
+
+    ast_reset(instr_base);
+
+    let parsed_idx: i32 = parse_simple_expression_ast(
+        base,
+        len,
+        offset,
+        locals_base,
+        locals_count_ptr,
+        ast_base,
+        ast_offset_ptr,
+        ast_root_ptr,
+    );
+
+    if parsed_idx >= 0 {
+        let root: i32 = load_i32(ast_root_ptr);
+        if root >= 0 {
+            let mut valid_trailing: bool = false;
+            let trimmed: i32 = skip_whitespace(base, len, parsed_idx);
+            if trimmed >= len {
+                valid_trailing = true;
+            } else {
+                let next_byte: i32 = peek_byte(base, len, trimmed);
+                if next_byte == 41 || next_byte == 44 || next_byte == 59 || next_byte == 125 || next_byte == 93 {
+                    valid_trailing = true;
+                };
+            };
+            if valid_trailing {
+                set_expr_type(expr_type_ptr, type_code_i32());
+                if lower_simple_ast(ast_base, root, instr_base, instr_offset_ptr) >= 0 {
+                    ast_reset(instr_base);
+                    return parsed_idx;
+                };
+            };
+        };
+    };
+
+    store_i32(ast_offset_ptr, saved_ast_offset);
+    store_i32(ast_root_ptr, saved_root);
+    store_i32(instr_offset_ptr, saved_instr_offset);
+
+    parse_expression_lowering(
+        base,
+        len,
+        offset,
+        instr_base,
+        instr_offset_ptr,
+        locals_base,
+        locals_count_ptr,
+        control_stack_base,
+        control_stack_count_ptr,
+        functions_base,
+        functions_count_ptr,
+        expr_type_ptr,
+    )
+}
+
+fn parse_expression_lowering(
+    base: i32,
+    len: i32,
+    offset: i32,
+    instr_base: i32,
+    instr_offset_ptr: i32,
+    locals_base: i32,
+    locals_count_ptr: i32,
+    control_stack_base: i32,
+    control_stack_count_ptr: i32,
+    functions_base: i32,
+    functions_count_ptr: i32,
+    expr_type_ptr: i32
+) -> i32 {
+    parse_or_lowering(
         base,
         len,
         offset,
@@ -1664,7 +2259,7 @@ fn parse_expression(
         )
 }
 
-fn parse_or(
+fn parse_or_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -1678,7 +2273,7 @@ fn parse_or(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    let mut idx: i32 = parse_and(
+    let mut idx: i32 = parse_and_lowering(
         base,
         len,
         offset,
@@ -1730,7 +2325,7 @@ fn parse_or(
             store_i32(instr_offset_ptr, saved_instr_offset);
             return -1;
         };
-        let next_idx: i32 = parse_and(
+        let next_idx: i32 = parse_and_lowering(
             base,
             len,
             idx,
@@ -1764,7 +2359,7 @@ fn parse_or(
     set_expr_type(expr_type_ptr, current_type);
     idx
 }
-fn parse_and(
+fn parse_and_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -1778,7 +2373,7 @@ fn parse_and(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    let mut idx: i32 = parse_bitwise_or(
+    let mut idx: i32 = parse_bitwise_or_lowering(
         base,
         len,
         offset,
@@ -1827,7 +2422,7 @@ fn parse_and(
             store_i32(instr_offset_ptr, saved_instr_offset);
             return -1;
         };
-        let next_idx: i32 = parse_bitwise_or(
+        let next_idx: i32 = parse_bitwise_or_lowering(
             base,
             len,
             idx,
@@ -1866,7 +2461,7 @@ fn parse_and(
     idx
 }
 
-fn parse_bitwise_or(
+fn parse_bitwise_or_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -1880,7 +2475,7 @@ fn parse_bitwise_or(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    let mut idx: i32 = parse_bitwise_and(
+    let mut idx: i32 = parse_bitwise_and_lowering(
         base,
         len,
         offset,
@@ -1926,7 +2521,7 @@ fn parse_bitwise_or(
         };
 
         idx = idx + 1;
-        let next_idx: i32 = parse_bitwise_and(
+        let next_idx: i32 = parse_bitwise_and_lowering(
             base,
             len,
             idx,
@@ -1966,7 +2561,7 @@ fn parse_bitwise_or(
     idx
 }
 
-fn parse_bitwise_and(
+fn parse_bitwise_and_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -1980,7 +2575,7 @@ fn parse_bitwise_and(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    let mut idx: i32 = parse_equality(
+    let mut idx: i32 = parse_equality_lowering(
         base,
         len,
         offset,
@@ -2026,7 +2621,7 @@ fn parse_bitwise_and(
         };
 
         idx = idx + 1;
-        let next_idx: i32 = parse_equality(
+        let next_idx: i32 = parse_equality_lowering(
             base,
             len,
             idx,
@@ -2065,7 +2660,7 @@ fn parse_bitwise_and(
 
     idx
 }
-fn parse_equality(
+fn parse_equality_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -2079,7 +2674,7 @@ fn parse_equality(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    let mut idx: i32 = parse_comparison(
+    let mut idx: i32 = parse_comparison_lowering(
         base,
         len,
         offset,
@@ -2113,7 +2708,7 @@ fn parse_equality(
         if first == 61 && second == 61 {
             idx = idx + 2;
             let left_type: i32 = current_type;
-            let next_idx: i32 = parse_comparison(
+            let next_idx: i32 = parse_comparison_lowering(
                 base,
                 len,
                 idx,
@@ -2146,7 +2741,7 @@ fn parse_equality(
         if first == 33 && second == 61 {
             idx = idx + 2;
             let left_type: i32 = current_type;
-            let next_idx: i32 = parse_comparison(
+            let next_idx: i32 = parse_comparison_lowering(
                 base,
                 len,
                 idx,
@@ -2189,7 +2784,7 @@ fn parse_equality(
 
     idx
 }
-fn parse_comparison(
+fn parse_comparison_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -2203,7 +2798,7 @@ fn parse_comparison(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    let mut idx: i32 = parse_shift(
+    let mut idx: i32 = parse_shift_lowering(
         base,
         len,
         offset,
@@ -2283,7 +2878,7 @@ fn parse_comparison(
         };
 
         idx = idx + consumed;
-        let next_idx: i32 = parse_shift(
+        let next_idx: i32 = parse_shift_lowering(
             base,
             len,
             idx,
@@ -2331,7 +2926,7 @@ fn parse_comparison(
     idx
 }
 
-fn parse_shift(
+fn parse_shift_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -2345,7 +2940,7 @@ fn parse_shift(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    let mut idx: i32 = parse_addition(
+    let mut idx: i32 = parse_addition_lowering(
         base,
         len,
         offset,
@@ -2399,7 +2994,7 @@ fn parse_shift(
         };
 
         idx = idx + 2;
-        let next_idx: i32 = parse_addition(
+        let next_idx: i32 = parse_addition_lowering(
             base,
             len,
             idx,
@@ -2441,7 +3036,7 @@ fn parse_shift(
 
     idx
 }
-fn parse_addition(
+fn parse_addition_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -2455,7 +3050,7 @@ fn parse_addition(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    let mut idx: i32 = parse_multiplication(
+    let mut idx: i32 = parse_multiplication_lowering(
         base,
         len,
         offset,
@@ -2488,7 +3083,7 @@ fn parse_addition(
                 return -1;
             };
             idx = idx + 1;
-            let next_idx: i32 = parse_multiplication(
+            let next_idx: i32 = parse_multiplication_lowering(
                 base,
                 len,
                 idx,
@@ -2537,7 +3132,7 @@ fn parse_addition(
 
     idx
 }
-fn parse_multiplication(
+fn parse_multiplication_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -2551,7 +3146,7 @@ fn parse_multiplication(
     functions_count_ptr: i32,
     expr_type_ptr: i32
 ) -> i32 {
-    let mut idx: i32 = parse_unary(
+    let mut idx: i32 = parse_unary_lowering(
         base,
         len,
         offset,
@@ -2584,7 +3179,7 @@ fn parse_multiplication(
                 return -1;
             };
             idx = idx + 1;
-            let next_idx: i32 = parse_unary(
+            let next_idx: i32 = parse_unary_lowering(
                 base,
                 len,
                 idx,
@@ -2633,7 +3228,7 @@ fn parse_multiplication(
 
     idx
 }
-fn parse_unary(
+fn parse_unary_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -2681,7 +3276,7 @@ fn parse_unary(
         store_i32(instr_offset_ptr, instr_offset);
     };
 
-    let mut next_idx: i32 = parse_primary(
+    let mut next_idx: i32 = parse_primary_lowering(
         base,
         len,
         idx,
@@ -2721,7 +3316,7 @@ fn parse_unary(
 
     next_idx
 }
-fn parse_primary(
+fn parse_primary_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -2778,7 +3373,7 @@ fn parse_primary(
             if third == 111 && fourth == 112 {
                 let after_keyword: i32 = idx + 4;
                 if after_keyword == len || !is_identifier_continue(peek_byte(base, len, after_keyword)) {
-                    return parse_loop_expression(
+                    return parse_loop_expression_lowering(
                         base,
                         len,
                         idx,
@@ -3574,7 +4169,7 @@ fn parse_loop_statement(
     after_loop
 }
 
-fn parse_loop_expression(
+fn parse_loop_expression_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -4180,7 +4775,7 @@ fn parse_block_statements(
     result
 }
 
-fn parse_block_expression(
+fn parse_block_expression_lowering(
     base: i32,
     len: i32,
     offset: i32,
@@ -4519,7 +5114,7 @@ fn parse_if_expression(
         control_type_none()
     );
 
-    let mut after_block: i32 = parse_block_expression(
+    let mut after_block: i32 = parse_block_expression_lowering(
         base,
         len,
         idx,
@@ -4577,7 +5172,7 @@ fn parse_if_expression(
     let next_byte: i32 = peek_byte(base, len, idx);
     if next_byte == 123 {
         idx = expect_char(base, len, idx, 123);
-        idx = parse_block_expression(
+        idx = parse_block_expression_lowering(
                     base,
                     len,
                     idx,


### PR DESCRIPTION
## Summary
- add scratch memory helpers and AST node constructors for an intermediate expression tree
- parse simple arithmetic expressions into AST nodes before falling back to the legacy lowering path
- note the new infrastructure progress in the TODO status entry

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e06c4e3cc483299f4509830ec966e9