### PR TITLE
Add shift expressions to simple AST lowering

### DIFF
--- a/compiler/stage1.bp
+++ b/compiler/stage1.bp
@@ -248,6 +248,14 @@ fn ast_kind_binary_ge() -> i32 {
     13
 }
 
+fn ast_kind_binary_shl() -> i32 {
+    14
+}
+
+fn ast_kind_binary_shr() -> i32 {
+    15
+}
+
 fn ast_reset(instr_base: i32) {
     let ast_offset_ptr: i32 = scratch_ast_offset_ptr_from_instr_base(instr_base);
     let ast_root_ptr: i32 = scratch_ast_root_ptr_from_instr_base(instr_base);
@@ -700,6 +708,70 @@ fn parse_simple_comparison_ast(
     };
 
     let mut current_node: i32 = load_i32(node_out_ptr);
+
+    loop {
+        idx = skip_whitespace(base, len, idx);
+        if idx >= len {
+            break;
+        };
+        if idx + 1 >= len {
+            break;
+        };
+        let first: i32 = peek_byte(base, len, idx);
+        let second: i32 = peek_byte(base, len, idx + 1);
+        let mut op_kind: i32 = -1;
+        if first == 60 && second == 60 {
+            op_kind = 0;
+        } else if first == 62 && second == 62 {
+            op_kind = 1;
+        } else {
+            break;
+        };
+
+        if ast_node_type(current_node) != type_code_i32() {
+            return -3;
+        };
+
+        idx = idx + 2;
+        idx = parse_simple_addition_ast(
+            base,
+            len,
+            idx,
+            locals_base,
+            locals_count_ptr,
+            ast_base,
+            ast_offset_ptr,
+            node_out_ptr,
+        );
+        if idx < 0 {
+            return idx;
+        };
+        let right_node: i32 = load_i32(node_out_ptr);
+        if ast_node_type(right_node) != type_code_i32() {
+            return -3;
+        };
+
+        let node_kind: i32 = if op_kind == 0 {
+            ast_kind_binary_shl()
+        } else {
+            ast_kind_binary_shr()
+        };
+        let new_node: i32 = ast_make_binary(
+            ast_base,
+            ast_offset_ptr,
+            node_kind,
+            current_node,
+            right_node,
+            type_code_i32(),
+        );
+        if new_node < 0 {
+            return -3;
+        };
+
+        current_node = new_node;
+        store_i32(node_out_ptr, current_node);
+    };
+
     let mut current_type: i32 = ast_node_type(current_node);
 
     loop {
@@ -967,6 +1039,22 @@ fn lower_simple_ast_node(
             return emit_mul(instr_base, next_offset);
         };
         return emit_div(instr_base, next_offset);
+    };
+    if kind == ast_kind_binary_shl() || kind == ast_kind_binary_shr() {
+        let left: i32 = load_i32(node_ptr + 4);
+        let right: i32 = load_i32(node_ptr + 8);
+        let mut next_offset: i32 = lower_simple_ast_node(ast_base, left, instr_base, offset);
+        if next_offset < 0 {
+            return -1;
+        };
+        next_offset = lower_simple_ast_node(ast_base, right, instr_base, next_offset);
+        if next_offset < 0 {
+            return -1;
+        };
+        if kind == ast_kind_binary_shl() {
+            return emit_shl(instr_base, next_offset);
+        };
+        return emit_shr_s(instr_base, next_offset);
     };
     if kind == ast_kind_binary_eq()
         || kind == ast_kind_binary_ne()


### PR DESCRIPTION
## Summary
- extend the simple expression AST to build nodes for << and >> operators
- lower the new shift AST nodes into the existing Wasm emitters
- fall back to the legacy lowering path when non-i32 operands appear in shift chains

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e07e431e9083299bb876f8f48ebbc3