### PR TITLE
Increase Wasm memory allocation for the compiler

### DIFF
--- a/compiler/stage1.bp
+++ b/compiler/stage1.bp
@@ -45,6 +45,10 @@ fn word_size() -> i32 {
     4
 }
 
+fn stage1_memory_pages() -> i32 {
+    256
+}
+
 fn scratch_instr_offset() -> i32 {
     4096
 }
@@ -2432,11 +2436,14 @@ fn write_function_section(base: i32, offset: i32, func_count: i32) -> i32 {
 
 fn write_memory_section(base: i32, offset: i32) -> i32 {
     let mut out: i32 = offset;
+    let mut payload_len: i32 = leb_u32_len(1);
+    payload_len = payload_len + leb_u32_len(0);
+    payload_len = payload_len + leb_u32_len(stage1_memory_pages());
     out = write_byte(base, out, 5);
-    out = write_u32_leb(base, out, 3);
+    out = write_u32_leb(base, out, payload_len);
     out = write_u32_leb(base, out, 1);
     out = write_u32_leb(base, out, 0);
-    out = write_u32_leb(base, out, 16);
+    out = write_u32_leb(base, out, stage1_memory_pages());
     out
 }
 

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -35,7 +35,7 @@ fn main() -> i32 {
         .current_pages(&store)
         .to_bytes()
         .expect("memory size to fit into usize");
-    assert_eq!(memory_bytes, 1048576);
+    assert_eq!(memory_bytes, 16777216);
 
     let slice_len: TypedFunc<(i32, i32), i32> = instance
         .get_typed_func(&mut store, "slice_len")

--- a/tests/wasm_harness.rs
+++ b/tests/wasm_harness.rs
@@ -228,7 +228,7 @@ pub fn run_wasm_main(engine: &Engine, wasm: &[u8]) -> i32 {
             .current_pages(&store)
             .to_bytes()
             .expect("memory pages to bytes"),
-        1048576
+        16777216
     );
 
     let main_fn: TypedFunc<(), i32> = instance


### PR DESCRIPTION
## Summary
- add a helper for the desired linear-memory size and emit dynamic section metadata when writing the stage1 memory section
- expand the compiler's linear-memory allocation to 256 pages (16 MiB)
- update tests to reflect the larger exported memory footprint
- revert stage2.wasm to its previous version so the artifact update can land separately

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e081ad31c88329b54852b41c7ef942