### PR TITLE
Extend AST parsing to bitwise operators

### DIFF
--- a/compiler/stage1.bp
+++ b/compiler/stage1.bp
@@ -260,6 +260,14 @@ fn ast_kind_binary_shr() -> i32 {
     15
 }
 
+fn ast_kind_binary_bitwise_and() -> i32 {
+    16
+}
+
+fn ast_kind_binary_bitwise_or() -> i32 {
+    17
+}
+
 fn ast_reset(instr_base: i32) {
     let ast_offset_ptr: i32 = scratch_ast_offset_ptr_from_instr_base(instr_base);
     let ast_root_ptr: i32 = scratch_ast_root_ptr_from_instr_base(instr_base);
@@ -972,6 +980,180 @@ fn parse_simple_equality_ast(
     idx
 }
 
+fn parse_simple_bitwise_or_ast(
+    base: i32,
+    len: i32,
+    offset: i32,
+    locals_base: i32,
+    locals_count_ptr: i32,
+    ast_base: i32,
+    ast_offset_ptr: i32,
+    node_out_ptr: i32,
+) -> i32 {
+    let mut idx: i32 = parse_simple_bitwise_and_ast(
+        base,
+        len,
+        offset,
+        locals_base,
+        locals_count_ptr,
+        ast_base,
+        ast_offset_ptr,
+        node_out_ptr,
+    );
+    if idx < 0 {
+        return idx;
+    };
+
+    let mut current_node: i32 = load_i32(node_out_ptr);
+
+    loop {
+        idx = skip_whitespace(base, len, idx);
+        if idx >= len {
+            break;
+        };
+
+        let op_byte: i32 = peek_byte(base, len, idx);
+        if op_byte != 124 {
+            break;
+        };
+        if idx + 1 < len {
+            let next: i32 = peek_byte(base, len, idx + 1);
+            if next == 124 {
+                break;
+            };
+        };
+
+        if ast_node_type(current_node) != type_code_i32() {
+            return -3;
+        };
+
+        idx = idx + 1;
+        idx = parse_simple_bitwise_and_ast(
+            base,
+            len,
+            idx,
+            locals_base,
+            locals_count_ptr,
+            ast_base,
+            ast_offset_ptr,
+            node_out_ptr,
+        );
+        if idx < 0 {
+            return idx;
+        };
+
+        let right_node: i32 = load_i32(node_out_ptr);
+        if ast_node_type(right_node) != type_code_i32() {
+            return -3;
+        };
+
+        let new_node: i32 = ast_make_binary(
+            ast_base,
+            ast_offset_ptr,
+            ast_kind_binary_bitwise_or(),
+            current_node,
+            right_node,
+            type_code_i32(),
+        );
+        if new_node < 0 {
+            return -3;
+        };
+
+        current_node = new_node;
+        store_i32(node_out_ptr, current_node);
+    };
+
+    store_i32(node_out_ptr, current_node);
+    idx
+}
+
+fn parse_simple_bitwise_and_ast(
+    base: i32,
+    len: i32,
+    offset: i32,
+    locals_base: i32,
+    locals_count_ptr: i32,
+    ast_base: i32,
+    ast_offset_ptr: i32,
+    node_out_ptr: i32,
+) -> i32 {
+    let mut idx: i32 = parse_simple_equality_ast(
+        base,
+        len,
+        offset,
+        locals_base,
+        locals_count_ptr,
+        ast_base,
+        ast_offset_ptr,
+        node_out_ptr,
+    );
+    if idx < 0 {
+        return idx;
+    };
+
+    let mut current_node: i32 = load_i32(node_out_ptr);
+
+    loop {
+        idx = skip_whitespace(base, len, idx);
+        if idx >= len {
+            break;
+        };
+
+        let op_byte: i32 = peek_byte(base, len, idx);
+        if op_byte != 38 {
+            break;
+        };
+        if idx + 1 < len {
+            let next: i32 = peek_byte(base, len, idx + 1);
+            if next == 38 {
+                break;
+            };
+        };
+
+        if ast_node_type(current_node) != type_code_i32() {
+            return -3;
+        };
+
+        idx = idx + 1;
+        idx = parse_simple_equality_ast(
+            base,
+            len,
+            idx,
+            locals_base,
+            locals_count_ptr,
+            ast_base,
+            ast_offset_ptr,
+            node_out_ptr,
+        );
+        if idx < 0 {
+            return idx;
+        };
+
+        let right_node: i32 = load_i32(node_out_ptr);
+        if ast_node_type(right_node) != type_code_i32() {
+            return -3;
+        };
+
+        let new_node: i32 = ast_make_binary(
+            ast_base,
+            ast_offset_ptr,
+            ast_kind_binary_bitwise_and(),
+            current_node,
+            right_node,
+            type_code_i32(),
+        );
+        if new_node < 0 {
+            return -3;
+        };
+
+        current_node = new_node;
+        store_i32(node_out_ptr, current_node);
+    };
+
+    store_i32(node_out_ptr, current_node);
+    idx
+}
+
 fn parse_simple_expression_ast(
     base: i32,
     len: i32,
@@ -982,7 +1164,7 @@ fn parse_simple_expression_ast(
     ast_offset_ptr: i32,
     node_out_ptr: i32,
 ) -> i32 {
-    parse_simple_equality_ast(
+    parse_simple_bitwise_or_ast(
         base,
         len,
         offset,
@@ -1043,6 +1225,22 @@ fn lower_simple_ast_node(
             return emit_mul(instr_base, next_offset);
         };
         return emit_div(instr_base, next_offset);
+    };
+    if kind == ast_kind_binary_bitwise_and() || kind == ast_kind_binary_bitwise_or() {
+        let left: i32 = load_i32(node_ptr + 4);
+        let right: i32 = load_i32(node_ptr + 8);
+        let mut next_offset: i32 = lower_simple_ast_node(ast_base, left, instr_base, offset);
+        if next_offset < 0 {
+            return -1;
+        };
+        next_offset = lower_simple_ast_node(ast_base, right, instr_base, next_offset);
+        if next_offset < 0 {
+            return -1;
+        };
+        if kind == ast_kind_binary_bitwise_and() {
+            return emit_and(instr_base, next_offset);
+        };
+        return emit_or(instr_base, next_offset);
     };
     if kind == ast_kind_binary_shl() || kind == ast_kind_binary_shr() {
         let left: i32 = load_i32(node_ptr + 4);


### PR DESCRIPTION
## Summary
- add AST node kinds for bitwise and/or operations
- extend simple expression parsing to build ASTs for `&` and `|`
- lower the new AST nodes to existing bitwise wasm instructions

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e08e6540788329b5d15dc1a57dfd31