### PR TITLE
Add constant folding pass for stage1 AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
 name = "bootstrap"
 version = "0.1.0"
 dependencies = [
  "wasmi",
+ "wasmparser",
 ]
 
 [[package]]
@@ -20,6 +27,46 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+ "serde",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "indexmap"
+version = "2.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.0",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "indexmap-nostd"
@@ -49,6 +96,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +159,23 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "wasmi"
@@ -89,6 +206,19 @@ dependencies = [
  "libm",
  "num-traits",
  "paste",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.239.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 wasmi = "0.31"
+
+[dev-dependencies]
+wasmparser = "0.239"

--- a/compiler/stage1.bp
+++ b/compiler/stage1.bp
@@ -313,6 +313,32 @@ fn ast_node_type(node_ptr: i32) -> i32 {
     load_i32(node_ptr + 12)
 }
 
+fn ast_node_kind(node_ptr: i32) -> i32 {
+    load_i32(node_ptr)
+}
+
+fn ast_is_i32_const(node_ptr: i32) -> bool {
+    if node_ptr < 0 {
+        return false;
+    };
+    ast_node_kind(node_ptr) == ast_kind_i32_const()
+}
+
+fn ast_is_bool_const(node_ptr: i32) -> bool {
+    if node_ptr < 0 {
+        return false;
+    };
+    ast_node_kind(node_ptr) == ast_kind_bool_const()
+}
+
+fn ast_i32_const_value(node_ptr: i32) -> i32 {
+    load_i32(node_ptr + 4)
+}
+
+fn ast_bool_const_value(node_ptr: i32) -> bool {
+    load_i32(node_ptr + 4) != 0
+}
+
 fn ast_make_i32_const(ast_base: i32, ast_offset_ptr: i32, value: i32) -> i32 {
     let node_ptr: i32 = ast_allocate_node(ast_base, ast_offset_ptr, ast_kind_i32_const());
     if node_ptr < 0 {
@@ -383,6 +409,223 @@ fn ast_make_unary(
     };
     store_i32(node_ptr + 4, operand);
     ast_node_set_type(node_ptr, result_type);
+    node_ptr
+}
+
+fn ast_fold_constants(ast_base: i32, ast_offset_ptr: i32, node_ptr: i32) -> i32 {
+    if node_ptr < 0 {
+        return -1;
+    };
+    let kind: i32 = ast_node_kind(node_ptr);
+    if kind == ast_kind_i32_const() || kind == ast_kind_bool_const() || kind == ast_kind_local_get() {
+        return node_ptr;
+    };
+
+    if kind == ast_kind_unary_neg() || kind == ast_kind_unary_not() {
+        let operand: i32 = load_i32(node_ptr + 4);
+        let folded_operand: i32 = ast_fold_constants(ast_base, ast_offset_ptr, operand);
+        if folded_operand < 0 {
+            return -1;
+        };
+        if folded_operand != operand {
+            store_i32(node_ptr + 4, folded_operand);
+        };
+        if kind == ast_kind_unary_neg() {
+            if ast_is_i32_const(folded_operand) {
+                let value: i32 = ast_i32_const_value(folded_operand);
+                let new_node: i32 = ast_make_i32_const(ast_base, ast_offset_ptr, 0 - value);
+                if new_node < 0 {
+                    return -1;
+                };
+                return new_node;
+            };
+        } else if ast_is_bool_const(folded_operand) {
+            let inverted: bool = !ast_bool_const_value(folded_operand);
+            let new_node: i32 = ast_make_bool_const(ast_base, ast_offset_ptr, inverted);
+            if new_node < 0 {
+                return -1;
+            };
+            return new_node;
+        };
+        return node_ptr;
+    };
+
+    let left: i32 = load_i32(node_ptr + 4);
+    let right: i32 = load_i32(node_ptr + 8);
+    let folded_left: i32 = ast_fold_constants(ast_base, ast_offset_ptr, left);
+    if folded_left < 0 {
+        return -1;
+    };
+    let folded_right: i32 = ast_fold_constants(ast_base, ast_offset_ptr, right);
+    if folded_right < 0 {
+        return -1;
+    };
+    if folded_left != left {
+        store_i32(node_ptr + 4, folded_left);
+    };
+    if folded_right != right {
+        store_i32(node_ptr + 8, folded_right);
+    };
+
+    if kind == ast_kind_binary_add()
+        || kind == ast_kind_binary_sub()
+        || kind == ast_kind_binary_mul()
+        || kind == ast_kind_binary_div()
+    {
+        if ast_is_i32_const(folded_left) && ast_is_i32_const(folded_right) {
+            let left_value: i32 = ast_i32_const_value(folded_left);
+            let right_value: i32 = ast_i32_const_value(folded_right);
+            if kind == ast_kind_binary_div() {
+                if right_value == 0 {
+                    return node_ptr;
+                };
+                if left_value == -2147483648 && right_value == -1 {
+                    return node_ptr;
+                };
+            };
+            let mut result: i32 = 0;
+            if kind == ast_kind_binary_add() {
+                result = left_value + right_value;
+            } else if kind == ast_kind_binary_sub() {
+                result = left_value - right_value;
+            } else if kind == ast_kind_binary_mul() {
+                result = left_value * right_value;
+            } else {
+                result = left_value / right_value;
+            };
+            let new_node: i32 = ast_make_i32_const(ast_base, ast_offset_ptr, result);
+            if new_node < 0 {
+                return -1;
+            };
+            return new_node;
+        };
+        return node_ptr;
+    };
+
+    if kind == ast_kind_binary_bitwise_and() || kind == ast_kind_binary_bitwise_or() {
+        if ast_is_i32_const(folded_left) && ast_is_i32_const(folded_right) {
+            let left_value: i32 = ast_i32_const_value(folded_left);
+            let right_value: i32 = ast_i32_const_value(folded_right);
+            let mut result: i32 = 0;
+            if kind == ast_kind_binary_bitwise_and() {
+                result = left_value & right_value;
+            } else {
+                result = left_value | right_value;
+            };
+            let new_node: i32 = ast_make_i32_const(ast_base, ast_offset_ptr, result);
+            if new_node < 0 {
+                return -1;
+            };
+            return new_node;
+        };
+        return node_ptr;
+    };
+
+    if kind == ast_kind_binary_shl() || kind == ast_kind_binary_shr() {
+        if ast_is_i32_const(folded_left) && ast_is_i32_const(folded_right) {
+            let left_value: i32 = ast_i32_const_value(folded_left);
+            let mut shift_amount: i32 = ast_i32_const_value(folded_right);
+            shift_amount = shift_amount & 31;
+            let mut result: i32 = 0;
+            if kind == ast_kind_binary_shl() {
+                result = left_value << shift_amount;
+            } else {
+                result = left_value >> shift_amount;
+            };
+            let new_node: i32 = ast_make_i32_const(ast_base, ast_offset_ptr, result);
+            if new_node < 0 {
+                return -1;
+            };
+            return new_node;
+        };
+        return node_ptr;
+    };
+
+    if kind == ast_kind_binary_eq() || kind == ast_kind_binary_ne() {
+        let left_type: i32 = ast_node_type(folded_left);
+        if left_type == type_code_i32() {
+            if ast_is_i32_const(folded_left) && ast_is_i32_const(folded_right) {
+                let left_value: i32 = ast_i32_const_value(folded_left);
+                let right_value: i32 = ast_i32_const_value(folded_right);
+                let mut matches: bool = false;
+                if kind == ast_kind_binary_eq() {
+                    matches = left_value == right_value;
+                } else {
+                    matches = left_value != right_value;
+                };
+                let new_node: i32 = ast_make_bool_const(ast_base, ast_offset_ptr, matches);
+                if new_node < 0 {
+                    return -1;
+                };
+                return new_node;
+            };
+        } else if left_type == type_code_bool() {
+            if ast_is_bool_const(folded_left) && ast_is_bool_const(folded_right) {
+                let left_value: bool = ast_bool_const_value(folded_left);
+                let right_value: bool = ast_bool_const_value(folded_right);
+                let mut matches: bool = false;
+                if kind == ast_kind_binary_eq() {
+                    matches = left_value == right_value;
+                } else {
+                    matches = left_value != right_value;
+                };
+                let new_node: i32 = ast_make_bool_const(ast_base, ast_offset_ptr, matches);
+                if new_node < 0 {
+                    return -1;
+                };
+                return new_node;
+            };
+        };
+        return node_ptr;
+    };
+
+    if kind == ast_kind_binary_lt()
+        || kind == ast_kind_binary_gt()
+        || kind == ast_kind_binary_le()
+        || kind == ast_kind_binary_ge()
+    {
+        if ast_is_i32_const(folded_left) && ast_is_i32_const(folded_right) {
+            let left_value: i32 = ast_i32_const_value(folded_left);
+            let right_value: i32 = ast_i32_const_value(folded_right);
+            let mut result: bool = false;
+            if kind == ast_kind_binary_lt() {
+                result = left_value < right_value;
+            } else if kind == ast_kind_binary_gt() {
+                result = left_value > right_value;
+            } else if kind == ast_kind_binary_le() {
+                result = left_value <= right_value;
+            } else {
+                result = left_value >= right_value;
+            };
+            let new_node: i32 = ast_make_bool_const(ast_base, ast_offset_ptr, result);
+            if new_node < 0 {
+                return -1;
+            };
+            return new_node;
+        };
+        return node_ptr;
+    };
+
+    if kind == ast_kind_binary_logical_and() {
+        if ast_is_bool_const(folded_left) {
+            if !ast_bool_const_value(folded_left) {
+                return folded_left;
+            };
+            return folded_right;
+        };
+        return node_ptr;
+    };
+
+    if kind == ast_kind_binary_logical_or() {
+        if ast_is_bool_const(folded_left) {
+            if ast_bool_const_value(folded_left) {
+                return folded_left;
+            };
+            return folded_right;
+        };
+        return node_ptr;
+    };
+
     node_ptr
 }
 
@@ -3166,25 +3409,29 @@ fn parse_expression(
     if parsed_idx >= 0 {
         let root: i32 = load_i32(ast_root_ptr);
         if root >= 0 {
-            let root_type: i32 = ast_node_type(root);
-            if root_type >= 0 {
-            let mut valid_trailing: bool = false;
-            let trimmed: i32 = skip_whitespace(base, len, parsed_idx);
-            if trimmed >= len {
-                valid_trailing = true;
-            } else {
-                let next_byte: i32 = peek_byte(base, len, trimmed);
-                if next_byte == 41 || next_byte == 44 || next_byte == 59 || next_byte == 125 || next_byte == 93 {
-                    valid_trailing = true;
+            let normalized_root: i32 = ast_fold_constants(ast_base, ast_offset_ptr, root);
+            if normalized_root >= 0 {
+                store_i32(ast_root_ptr, normalized_root);
+                let root_type: i32 = ast_node_type(normalized_root);
+                if root_type >= 0 {
+                    let mut valid_trailing: bool = false;
+                    let trimmed: i32 = skip_whitespace(base, len, parsed_idx);
+                    if trimmed >= len {
+                        valid_trailing = true;
+                    } else {
+                        let next_byte: i32 = peek_byte(base, len, trimmed);
+                        if next_byte == 41 || next_byte == 44 || next_byte == 59 || next_byte == 125 || next_byte == 93 {
+                            valid_trailing = true;
+                        };
+                    };
+                    if valid_trailing {
+                        set_expr_type(expr_type_ptr, root_type);
+                        if lower_simple_ast(ast_base, normalized_root, instr_base, instr_offset_ptr) >= 0 {
+                            ast_reset(instr_base);
+                            return parsed_idx;
+                        };
+                    };
                 };
-            };
-            if valid_trailing {
-                set_expr_type(expr_type_ptr, root_type);
-                if lower_simple_ast(ast_base, root, instr_base, instr_offset_ptr) >= 0 {
-                    ast_reset(instr_base);
-                    return parsed_idx;
-                };
-            };
             };
         };
     };

--- a/tests/ast_passes.rs
+++ b/tests/ast_passes.rs
@@ -1,0 +1,93 @@
+#[path = "stage1_helpers.rs"]
+mod stage1_helpers;
+
+use stage1_helpers::compile_with_stage1;
+
+use wasmparser::{ExternalKind, Operator, Parser, Payload, TypeRef};
+
+#[test]
+fn ast_constant_folding_collapses_integer_expression() {
+    let source = r#"
+fn constant_expr() -> i32 {
+    (1 + 2) * (3 + 4)
+}
+
+fn main() -> i32 {
+    constant_expr()
+}
+"#;
+
+    let wasm = compile_with_stage1(source);
+
+    let parser = Parser::new(0);
+    let mut import_count: u32 = 0;
+    let mut defined_index: u32 = 0;
+    let mut target_func_index: Option<u32> = None;
+    let mut found_body = false;
+
+    for payload in parser.parse_all(&wasm) {
+        let payload = payload.expect("failed to parse wasm payload");
+        match payload {
+            Payload::ImportSection(imports) => {
+                for import in imports {
+                    let import = import.expect("failed to parse import");
+                    if let TypeRef::Func(_) = import.ty {
+                        import_count += 1;
+                    }
+                }
+            }
+            Payload::ExportSection(exports) => {
+                for export in exports {
+                    let export = export.expect("failed to parse export");
+                    if export.name == "constant_expr" {
+                        if let ExternalKind::Func = export.kind {
+                            target_func_index = Some(export.index);
+                        }
+                    }
+                }
+            }
+            Payload::CodeSectionEntry(body) => {
+                let func_index = import_count + defined_index;
+                if Some(func_index) == target_func_index {
+                    let mut locals_reader = body.get_locals_reader().expect("failed to read locals");
+                    for _ in 0..locals_reader.get_count() {
+                        locals_reader
+                            .read()
+                            .expect("failed to parse local declaration");
+                    }
+                    let mut operators = body
+                        .get_operators_reader()
+                        .expect("failed to read operators");
+                    let mut saw_const = false;
+                    let mut const_value: i32 = 0;
+                    while !operators.eof() {
+                        let op = operators.read().expect("failed to read operator");
+                        match op {
+                            Operator::I32Const { value } => {
+                                assert!(
+                                    !saw_const,
+                                    "unexpected multiple constants in constant_expr body"
+                                );
+                                saw_const = true;
+                                const_value = value;
+                            }
+                            Operator::End => break,
+                            Operator::Return => continue,
+                            other => panic!(
+                                "unexpected operator {:?} while checking constant folding",
+                                other
+                            ),
+                        }
+                    }
+                    assert!(saw_const, "expected i32.const in constant_expr body");
+                    assert_eq!(const_value, 21, "expected folded constant value");
+                    found_body = true;
+                }
+                defined_index += 1;
+            }
+            _ => {}
+        }
+    }
+
+    assert!(found_body, "failed to locate constant_expr body");
+}


### PR DESCRIPTION
## Summary
- add AST helpers and a constant-folding pass to simplify stage1 expression trees before lowering
- run the pass for parsed expressions so the emitter sees folded nodes
- add a wasmparser dev-dependency and a test that ensures arithmetic collapses to a single constant instruction

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68e09996c3708329b9169fb793f6f1a0