### PR TITLE
Validate unique AST function names

### DIFF
--- a/compiler/ast_compiler.bp
+++ b/compiler/ast_compiler.bp
@@ -508,7 +508,7 @@ fn validate_program(ast_base: i32, func_count: i32) -> i32 {
     if func_count <= 0 {
         return -1;
     };
-    let mut main_found: bool = false;
+    let mut main_count: i32 = 0;
     let main_name_ptr: i32 = ast_extra_base(ast_base);
     store_u8(main_name_ptr + 0, 109);
     store_u8(main_name_ptr + 1, 97);
@@ -524,12 +524,27 @@ fn validate_program(ast_base: i32, func_count: i32) -> i32 {
         let name_len: i32 = load_i32(entry_ptr + 4);
         if name_len == 4 {
             if identifiers_match(name_ptr, name_len, main_name_ptr, 4) {
-                main_found = true;
+                main_count = main_count + 1;
             };
+        };
+        let mut other_idx: i32 = idx + 1;
+        loop {
+            if other_idx >= func_count {
+                break;
+            };
+            let other_entry_ptr: i32 = ast_function_entry_ptr(ast_base, other_idx);
+            let other_name_ptr: i32 = load_i32(other_entry_ptr);
+            let other_name_len: i32 = load_i32(other_entry_ptr + 4);
+            if name_len == other_name_len {
+                if identifiers_match(name_ptr, name_len, other_name_ptr, other_name_len) {
+                    return -1;
+                };
+            };
+            other_idx = other_idx + 1;
         };
         idx = idx + 1;
     };
-    if !main_found {
+    if main_count != 1 {
         return -1;
     };
     0

--- a/tests/ast_compiler.rs
+++ b/tests/ast_compiler.rs
@@ -34,3 +34,45 @@ fn helper() -> i32 {
         .expect_err("ast compiler should reject programs without main");
     assert!(error.produced_len <= 0);
 }
+
+#[test]
+fn ast_compiler_rejects_duplicate_function_names() {
+    let source = r#"
+fn helper() -> i32 {
+    1
+}
+
+fn helper() -> i32 {
+    2
+}
+
+fn main() -> i32 {
+    3
+}
+"#;
+
+    let error = try_compile_with_ast_compiler(source)
+        .expect_err("ast compiler should reject duplicate function names");
+    assert!(error.produced_len <= 0);
+}
+
+#[test]
+fn ast_compiler_rejects_multiple_main_functions() {
+    let source = r#"
+fn main() -> i32 {
+    1
+}
+
+fn helper() -> i32 {
+    2
+}
+
+fn main() -> i32 {
+    3
+}
+"#;
+
+    let error = try_compile_with_ast_compiler(source)
+        .expect_err("ast compiler should reject programs with multiple mains");
+    assert!(error.produced_len <= 0);
+}


### PR DESCRIPTION
## Summary
- reject programs where AST functions share the same identifier
- require exactly one `main` function during AST validation
- add regression tests covering duplicate names and multiple `main` definitions

## Testing
- `cargo test ast_compiler`


------
https://chatgpt.com/codex/tasks/task_e_68e1a91130fc832980ce5b8e1dbf4aca