### PR TITLE
Add multiplicative expression support to AST compiler

### DIFF
--- a/compiler/ast_compiler.bp
+++ b/compiler/ast_compiler.bp
@@ -454,6 +454,14 @@ fn ast_expr_alloc_sub(ast_base: i32, left_index: i32, right_index: i32) -> i32 {
     ast_expr_alloc(ast_base, 3, left_index, right_index, 0)
 }
 
+fn ast_expr_alloc_mul(ast_base: i32, left_index: i32, right_index: i32) -> i32 {
+    ast_expr_alloc(ast_base, 4, left_index, right_index, 0)
+}
+
+fn ast_expr_alloc_div(ast_base: i32, left_index: i32, right_index: i32) -> i32 {
+    ast_expr_alloc(ast_base, 5, left_index, right_index, 0)
+}
+
 fn expression_node_from_parts(ast_base: i32, kind: i32, data0: i32, data1: i32) -> i32 {
     if kind == 0 {
         return ast_expr_alloc_literal(ast_base, data0);
@@ -544,7 +552,7 @@ fn parse_basic_expression(
     skip_whitespace(base, len, next_cursor)
 }
 
-fn parse_expression(
+fn parse_multiplicative_expression(
     base: i32,
     len: i32,
     cursor: i32,
@@ -584,7 +592,7 @@ fn parse_expression(
             break;
         };
         let next_byte: i32 = load_u8(base + current_cursor);
-        if next_byte != 43 && next_byte != 45 {
+        if next_byte != 42 && next_byte != 47 {
             break;
         };
         let operator: i32 = next_byte;
@@ -619,6 +627,95 @@ fn parse_expression(
         let right_data0: i32 = load_i32(next_data0_ptr);
         let right_data1: i32 = load_i32(next_data1_ptr);
         let right_index: i32 = expression_node_from_parts(ast_base, right_kind, right_data0, right_data1);
+        if right_index < 0 {
+            return -1;
+        };
+
+        let new_index: i32 = if operator == 42 {
+            ast_expr_alloc_mul(ast_base, left_index, right_index)
+        } else {
+            ast_expr_alloc_div(ast_base, left_index, right_index)
+        };
+        if new_index < 0 {
+            return -1;
+        };
+
+        store_i32(out_kind_ptr, 2);
+        store_i32(out_data0_ptr, new_index);
+        store_i32(out_data1_ptr, 0);
+    };
+
+    current_cursor
+}
+
+fn parse_expression(
+    base: i32,
+    len: i32,
+    cursor: i32,
+    ast_base: i32,
+    temp_base: i32,
+    out_kind_ptr: i32,
+    out_data0_ptr: i32,
+    out_data1_ptr: i32,
+) -> i32 {
+    let mult_temp_base: i32 = temp_base;
+    let next_kind_ptr: i32 = temp_base + 96;
+    let next_data0_ptr: i32 = temp_base + 100;
+    let next_data1_ptr: i32 = temp_base + 104;
+
+    let mut current_cursor: i32 = parse_multiplicative_expression(
+        base,
+        len,
+        cursor,
+        ast_base,
+        mult_temp_base,
+        out_kind_ptr,
+        out_data0_ptr,
+        out_data1_ptr,
+    );
+    if current_cursor < 0 {
+        return -1;
+    };
+
+    loop {
+        if current_cursor >= len {
+            break;
+        };
+        let next_byte: i32 = load_u8(base + current_cursor);
+        if next_byte != 43 && next_byte != 45 {
+            break;
+        };
+        let operator: i32 = next_byte;
+        current_cursor = current_cursor + 1;
+        current_cursor = skip_whitespace(base, len, current_cursor);
+        current_cursor = parse_multiplicative_expression(
+            base,
+            len,
+            current_cursor,
+            ast_base,
+            mult_temp_base,
+            next_kind_ptr,
+            next_data0_ptr,
+            next_data1_ptr,
+        );
+        if current_cursor < 0 {
+            return -1;
+        };
+
+        let current_kind: i32 = load_i32(out_kind_ptr);
+        let current_data0: i32 = load_i32(out_data0_ptr);
+        let current_data1: i32 = load_i32(out_data1_ptr);
+        let left_index: i32 =
+            expression_node_from_parts(ast_base, current_kind, current_data0, current_data1);
+        if left_index < 0 {
+            return -1;
+        };
+
+        let right_kind: i32 = load_i32(next_kind_ptr);
+        let right_data0: i32 = load_i32(next_data0_ptr);
+        let right_data1: i32 = load_i32(next_data1_ptr);
+        let right_index: i32 =
+            expression_node_from_parts(ast_base, right_kind, right_data0, right_data1);
         if right_index < 0 {
             return -1;
         };
@@ -908,7 +1005,7 @@ fn resolve_expression(ast_base: i32, expr_index: i32, func_count: i32) -> i32 {
         store_i32(entry_ptr + 12, target_idx);
         return 0;
     };
-    if kind == 2 || kind == 3 {
+    if kind == 2 || kind == 3 || kind == 4 || kind == 5 {
         let left_index: i32 = load_i32(entry_ptr + 4);
         let right_index: i32 = load_i32(entry_ptr + 8);
         if resolve_expression(ast_base, left_index, func_count) < 0 {
@@ -942,7 +1039,7 @@ fn expression_code_size(ast_base: i32, expr_index: i32) -> i32 {
         };
         return 1 + leb_u32_len(callee_index);
     };
-    if kind == 2 || kind == 3 {
+    if kind == 2 || kind == 3 || kind == 4 || kind == 5 {
         let left_index: i32 = load_i32(entry_ptr + 4);
         let right_index: i32 = load_i32(entry_ptr + 8);
         let left_size: i32 = expression_code_size(ast_base, left_index);
@@ -984,7 +1081,7 @@ fn emit_expression(base: i32, offset: i32, ast_base: i32, expr_index: i32) -> i3
         out = write_u32_leb(base, out, callee_index);
         return out;
     };
-    if kind == 2 || kind == 3 {
+    if kind == 2 || kind == 3 || kind == 4 || kind == 5 {
         let left_index: i32 = load_i32(entry_ptr + 4);
         let right_index: i32 = load_i32(entry_ptr + 8);
         let mut out: i32 = emit_expression(base, offset, ast_base, left_index);
@@ -995,7 +1092,19 @@ fn emit_expression(base: i32, offset: i32, ast_base: i32, expr_index: i32) -> i3
         if out < 0 {
             return -1;
         };
-        let opcode: i32 = if kind == 2 { 106 } else { 107 };
+        let opcode: i32 = if kind == 2 {
+            106
+        } else {
+            if kind == 3 {
+                107
+            } else {
+                if kind == 4 {
+                    108
+                } else {
+                    109
+                }
+            }
+        };
         out = write_byte(base, out, opcode);
         return out;
     };

--- a/tests/ast_compiler.rs
+++ b/tests/ast_compiler.rs
@@ -249,6 +249,93 @@ fn main() -> i32 {
 }
 
 #[test]
+fn ast_compiler_compiles_literal_multiplication() {
+    let source = r#"
+fn main() -> i32 {
+    6 * 7
+}
+"#;
+
+    let wasm = compile_with_ast_compiler(source);
+    let engine = wasmi::Engine::default();
+    let result = run_wasm_main(&engine, &wasm);
+    assert_eq!(result, 42);
+}
+
+#[test]
+fn ast_compiler_compiles_multiplication_with_function_call() {
+    let source = r#"
+fn helper() -> i32 {
+    6
+}
+
+fn main() -> i32 {
+    helper() * 7
+}
+"#;
+
+    let wasm = compile_with_ast_compiler(source);
+    let engine = wasmi::Engine::default();
+    let result = run_wasm_main(&engine, &wasm);
+    assert_eq!(result, 42);
+}
+
+#[test]
+fn ast_compiler_compiles_literal_division() {
+    let source = r#"
+fn main() -> i32 {
+    126 / 3
+}
+"#;
+
+    let wasm = compile_with_ast_compiler(source);
+    let engine = wasmi::Engine::default();
+    let result = run_wasm_main(&engine, &wasm);
+    assert_eq!(result, 42);
+}
+
+#[test]
+fn ast_compiler_respects_multiplication_precedence() {
+    let source = r#"
+fn main() -> i32 {
+    2 + 3 * 4
+}
+"#;
+
+    let wasm = compile_with_ast_compiler(source);
+    let engine = wasmi::Engine::default();
+    let result = run_wasm_main(&engine, &wasm);
+    assert_eq!(result, 14);
+}
+
+#[test]
+fn ast_compiler_rejects_unknown_function_in_multiplication() {
+    let source = r#"
+fn main() -> i32 {
+    3 * missing()
+}
+"#;
+
+    let error = try_compile_with_ast_compiler(source)
+        .expect_err("ast compiler should reject unknown calls in multiplication expressions");
+    assert!(error.produced_len <= 0);
+}
+
+#[test]
+fn ast_compiler_honors_parentheses_with_multiplication() {
+    let source = r#"
+fn main() -> i32 {
+    (2 + 3) * 4
+}
+"#;
+
+    let wasm = compile_with_ast_compiler(source);
+    let engine = wasmi::Engine::default();
+    let result = run_wasm_main(&engine, &wasm);
+    assert_eq!(result, 20);
+}
+
+#[test]
 fn ast_compiler_compiles_mixed_addition_and_subtraction() {
     let source = r#"
 fn main() -> i32 {


### PR DESCRIPTION
## Summary
- teach the AST compiler to emit multiplication and division nodes and opcodes
- refine expression parsing to respect multiplicative precedence over addition
- add tests covering multiplication, division, precedence, and related error cases

## Testing
- cargo test ast_compiler

------
https://chatgpt.com/codex/tasks/task_e_68e1bd7d1d3c832988222a68e9340aaa