### PR TITLE
Add continue statement support to AST compiler

### DIFF
--- a/compiler/ast_compiler.bp
+++ b/compiler/ast_compiler.bp
@@ -289,6 +289,48 @@ fn expect_keyword_break(base: i32, len: i32, offset: i32) -> i32 {
     next
 }
 
+fn expect_keyword_continue(base: i32, len: i32, offset: i32) -> i32 {
+    let mut idx: i32 = expect_char(base, len, offset, 99);
+    if idx < 0 {
+        return -1;
+    };
+    idx = expect_char(base, len, idx, 111);
+    if idx < 0 {
+        return -1;
+    };
+    idx = expect_char(base, len, idx, 110);
+    if idx < 0 {
+        return -1;
+    };
+    idx = expect_char(base, len, idx, 116);
+    if idx < 0 {
+        return -1;
+    };
+    idx = expect_char(base, len, idx, 105);
+    if idx < 0 {
+        return -1;
+    };
+    idx = expect_char(base, len, idx, 110);
+    if idx < 0 {
+        return -1;
+    };
+    idx = expect_char(base, len, idx, 117);
+    if idx < 0 {
+        return -1;
+    };
+    idx = expect_char(base, len, idx, 101);
+    if idx < 0 {
+        return -1;
+    };
+    if idx < len {
+        let next_byte: i32 = load_u8(base + idx);
+        if is_identifier_continue(next_byte) {
+            return -1;
+        };
+    };
+    idx
+}
+
 fn expect_keyword_return(base: i32, len: i32, offset: i32) -> i32 {
     if offset + 5 >= len {
         return -1;
@@ -546,9 +588,34 @@ fn parse_block_expression_body(
                     final_data0 = 0;
                     final_data1 = 0;
                 } else {
-                    store_i32(locals_stack_count_ptr, saved_stack_count);
-                    store_i32(locals_next_index_ptr, saved_next_index);
-                    return -1;
+                    let stmt_count: i32 = load_i32(statement_count_ptr);
+                    let mut diverges: bool = false;
+                    if stmt_count > 0 {
+                        let last_ptr: i32 =
+                            statements_base + (stmt_count - 1) * statement_entry_size;
+                        let last_kind: i32 = load_i32(last_ptr);
+                        if last_kind == 1 {
+                            let last_expr_index: i32 = load_i32(last_ptr + 4);
+                            if last_expr_index >= 0 {
+                                let expr_entry: i32 =
+                                    ast_expr_entry_ptr(ast_base, last_expr_index);
+                                let expr_kind: i32 = load_i32(expr_entry);
+                                if expr_kind == 13 || expr_kind == 24 || expr_kind == 23 {
+                                    diverges = true;
+                                };
+                            };
+                        };
+                    };
+                    if diverges {
+                        have_value_expr = true;
+                        final_kind = 0;
+                        final_data0 = 0;
+                        final_data1 = 0;
+                    } else {
+                        store_i32(locals_stack_count_ptr, saved_stack_count);
+                        store_i32(locals_next_index_ptr, saved_next_index);
+                        return -1;
+                    };
                 };
             };
             idx = idx + 1;
@@ -804,6 +871,50 @@ fn parse_block_expression_body(
             store_i32(stmt_ptr + 8, 0);
             store_i32(statement_count_ptr, stmt_count + 1);
             idx = after_break;
+            continue;
+        };
+
+        let mut continue_cursor: i32 = expect_keyword_continue(base, len, idx);
+        if continue_cursor >= 0 {
+            let current_loop_depth: i32 = load_i32(loop_depth_ptr);
+            if current_loop_depth <= 0 {
+                store_i32(locals_stack_count_ptr, saved_stack_count);
+                store_i32(locals_next_index_ptr, saved_next_index);
+                return -1;
+            };
+            if continue_cursor < len {
+                let after_byte: i32 = load_u8(base + continue_cursor);
+                if after_byte != 59 && !is_whitespace(after_byte) {
+                    store_i32(locals_stack_count_ptr, saved_stack_count);
+                    store_i32(locals_next_index_ptr, saved_next_index);
+                    return -1;
+                };
+            };
+            let mut after_continue: i32 = skip_whitespace(base, len, continue_cursor);
+            after_continue = expect_char(base, len, after_continue, 59);
+            if after_continue < 0 {
+                store_i32(locals_stack_count_ptr, saved_stack_count);
+                store_i32(locals_next_index_ptr, saved_next_index);
+                return -1;
+            };
+            let continue_expr_index: i32 = ast_expr_alloc_continue(ast_base);
+            if continue_expr_index < 0 {
+                store_i32(locals_stack_count_ptr, saved_stack_count);
+                store_i32(locals_next_index_ptr, saved_next_index);
+                return -1;
+            };
+            let stmt_count: i32 = load_i32(statement_count_ptr);
+            if stmt_count >= statements_capacity {
+                store_i32(locals_stack_count_ptr, saved_stack_count);
+                store_i32(locals_next_index_ptr, saved_next_index);
+                return -1;
+            };
+            let stmt_ptr: i32 = statements_base + stmt_count * statement_entry_size;
+            store_i32(stmt_ptr, 1);
+            store_i32(stmt_ptr + 4, continue_expr_index);
+            store_i32(stmt_ptr + 8, 0);
+            store_i32(statement_count_ptr, stmt_count + 1);
+            idx = skip_whitespace(base, len, after_continue);
             continue;
         };
 
@@ -1600,6 +1711,10 @@ fn ast_expr_alloc_loop(ast_base: i32, body_index: i32) -> i32 {
 
 fn ast_expr_alloc_break(ast_base: i32, value_index: i32) -> i32 {
     ast_expr_alloc(ast_base, 13, -1, value_index, 0)
+}
+
+fn ast_expr_alloc_continue(ast_base: i32) -> i32 {
+    ast_expr_alloc(ast_base, 24, -1, 0, 0)
 }
 
 fn ast_expr_alloc_return(ast_base: i32, value_index: i32) -> i32 {
@@ -3431,6 +3546,21 @@ fn resolve_expression_internal(
         };
         return 0;
     };
+    if kind == 24 {
+        let loop_count: i32 = load_i32(loop_stack_count_ptr);
+        if loop_count <= 0 {
+            return -1;
+        };
+        let target_index: i32 = load_i32(loop_stack_base + (loop_count - 1) * 4);
+        let continue_target: i32 = target_index + 1;
+        let control_count: i32 = load_i32(control_stack_count_ptr);
+        let branch_depth: i32 = control_count - 1 - continue_target;
+        if branch_depth < 0 {
+            return -1;
+        };
+        store_i32(entry_ptr + 4, branch_depth);
+        return 0;
+    };
     -1
 }
 
@@ -3637,6 +3767,13 @@ fn expression_code_size(ast_base: i32, expr_index: i32) -> i32 {
         };
         let const_size: i32 = 1 + leb_i32_len(0);
         return const_size + 1 + leb_u32_len(branch_depth);
+    };
+    if kind == 24 {
+        let branch_depth: i32 = load_i32(entry_ptr + 4);
+        if branch_depth < 0 {
+            return -1;
+        };
+        return 1 + leb_u32_len(branch_depth);
     };
     -1
 }
@@ -3919,6 +4056,16 @@ fn emit_expression(base: i32, offset: i32, ast_base: i32, expr_index: i32) -> i3
             out = write_byte(base, out, 65);
             out = write_i32_leb(base, out, 0);
         };
+        out = write_byte(base, out, 12);
+        out = write_u32_leb(base, out, branch_depth);
+        return out;
+    };
+    if kind == 24 {
+        let branch_depth: i32 = load_i32(entry_ptr + 4);
+        if branch_depth < 0 {
+            return -1;
+        };
+        let mut out: i32 = offset;
         out = write_byte(base, out, 12);
         out = write_u32_leb(base, out, branch_depth);
         return out;

--- a/docs/ast_compiler_self_hosting.md
+++ b/docs/ast_compiler_self_hosting.md
@@ -17,8 +17,6 @@ being able to compile its own source:
 - **Bitwise operators and shifts.** Encoding LEB128 values depends on `&`, `|`,
   and `>>`, operations that the expression allocator does not currently
   support.【F:compiler/ast_compiler.bp†L23-L68】【F:compiler/ast_compiler.bp†L1339-L1413】
-- **`continue` statements.** Loop bodies (such as comment skipping) use
-  `continue;`, a control-flow form that the parser does not yet handle.【F:compiler/ast_compiler.bp†L89-L119】【F:compiler/ast_compiler.bp†L440-L803】
 - **`return` statements.** Nearly every helper exits early with `return ...;`,
   so emitting function bodies requires first-class support for explicit returns
   instead of only relying on final block expressions.【F:compiler/ast_compiler.bp†L124-L132】【F:compiler/ast_compiler.bp†L440-L803】

--- a/tests/ast_compiler.rs
+++ b/tests/ast_compiler.rs
@@ -380,6 +380,65 @@ fn main() -> i32 {
 }
 
 #[test]
+fn ast_compiler_supports_continue_statements() {
+    let source = r#"
+fn sum_even(limit: i32) -> i32 {
+    let mut acc: i32 = 0;
+    let mut i: i32 = 0;
+    loop {
+        if i >= limit {
+            break;
+            0
+        } else {
+            0
+        };
+        i = i + 1;
+        let remainder: i32 = i - (i / 2) * 2;
+        if remainder == 1 {
+            continue;
+            0
+        } else {
+            0
+        };
+        acc = acc + i;
+    }
+    acc
+}
+
+fn loop_skip() -> i32 {
+    let mut total: i32 = 0;
+    let mut i: i32 = 0;
+    loop {
+        i = i + 1;
+        if i > 5 {
+            break;
+            0
+        } else {
+            0
+        };
+        if i == 3 {
+            continue;
+            0
+        } else {
+            0
+        };
+        total = total + i;
+    }
+    total
+}
+
+fn main() -> i32 {
+    sum_even(6) + loop_skip()
+}
+"#;
+
+    let wasm = compile_with_ast_compiler(source);
+    let engine = wasmi::Engine::default();
+    let result = run_wasm_main(&engine, &wasm);
+    assert_eq!(result, 24);
+}
+
+#[test]
 fn ast_compiler_loop_break_value_returns() {
     let source = r#"
 fn choose() -> i32 {
@@ -397,6 +456,20 @@ fn main() -> i32 {
     let engine = wasmi::Engine::default();
     let result = run_wasm_main(&engine, &wasm);
     assert_eq!(result, 42);
+}
+
+#[test]
+fn ast_compiler_rejects_continue_outside_loop() {
+    let source = r#"
+fn main() -> i32 {
+    continue;
+    0
+}
+"#;
+
+    let error = try_compile_with_ast_compiler(source)
+        .expect_err("ast compiler should reject continue outside loops");
+    assert!(error.produced_len <= 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add parsing support for `continue;` statements in the AST compiler, including branch resolution and wasm emission
- treat trailing diverging statements as satisfying block value requirements and allocate a dedicated continue AST node
- add regression tests for valid and invalid `continue` usage and document the remaining self-hosting gaps

## Testing
- `cargo test ast_compiler -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68e20d78a0ac83299339b5bce7aae834