### PR TITLE
Fix loop break resolution for call arguments in AST compiler

### DIFF
--- a/compiler/ast_compiler.bp
+++ b/compiler/ast_compiler.bp
@@ -4364,9 +4364,11 @@ fn resolve_expression(ast_base: i32, expr_index: i32, func_count: i32) -> i32 {
     let control_stack_base: i32 = temp_base + 8;
     let control_capacity: i32 = resolve_control_stack_capacity();
     let loop_stack_base: i32 = control_stack_base + control_capacity * 4;
+    let saved_control_count: i32 = load_i32(control_count_ptr);
+    let saved_loop_count: i32 = load_i32(loop_count_ptr);
     store_i32(control_count_ptr, 0);
     store_i32(loop_count_ptr, 0);
-    resolve_expression_internal(
+    let result: i32 = resolve_expression_internal(
         ast_base,
         expr_index,
         func_count,
@@ -4374,7 +4376,10 @@ fn resolve_expression(ast_base: i32, expr_index: i32, func_count: i32) -> i32 {
         control_count_ptr,
         loop_stack_base,
         loop_count_ptr,
-    )
+    );
+    store_i32(control_count_ptr, saved_control_count);
+    store_i32(loop_count_ptr, saved_loop_count);
+    result
 }
 
 fn expression_code_size(ast_base: i32, expr_index: i32) -> i32 {

--- a/tests/ast_compiler.rs
+++ b/tests/ast_compiler.rs
@@ -410,6 +410,35 @@ fn main() -> i32 {
 }
 
 #[test]
+fn ast_compiler_handles_predicate_calls_in_loops() {
+    let source = r#"
+fn predicate(value: i32) -> bool {
+    if value >= 3 {
+        true
+    } else {
+        false
+    }
+}
+
+fn main() -> i32 {
+    let mut value: i32 = 0;
+    loop {
+        if predicate(value) {
+            break;
+        };
+        value = value + 1;
+    }
+    value
+}
+"#;
+
+    let wasm = compile_with_ast_compiler(source);
+    let engine = wasmi::Engine::default();
+    let result = run_wasm_main(&engine, &wasm);
+    assert_eq!(result, 3);
+}
+
+#[test]
 fn ast_compiler_supports_functions_without_return_type() {
     let source = r#"
 fn helper() {


### PR DESCRIPTION
## Summary
- preserve the control and loop stack counters around `resolve_expression_internal` so call argument resolution no longer clears loop depth
- add a regression test to ensure predicate-style calls inside loops compile and execute correctly

## Testing
- cargo test *(fails in `bootstrap_ast::ast_compiler_compiler_bootstraps`)*

------
https://chatgpt.com/codex/tasks/task_e_68e254cf4c7883298995c28f788e947c