### PR TITLE
Adjust AST storage layout to avoid output overlap

### DIFF
--- a/compiler/ast_compiler.bp
+++ b/compiler/ast_compiler.bp
@@ -1786,8 +1786,12 @@ fn ast_call_data_capacity() -> i32 {
     65536
 }
 
-fn ast_program_base(out_ptr: i32) -> i32 {
-    scratch_instr_base(out_ptr)
+fn ast_output_reserve(input_len: i32) -> i32 {
+    input_len + scratch_instr_capacity()
+}
+
+fn ast_program_base(out_ptr: i32, input_len: i32) -> i32 {
+    out_ptr + ast_output_reserve(input_len)
 }
 
 fn ast_functions_count_ptr(ast_base: i32) -> i32 {
@@ -5103,15 +5107,20 @@ fn emit_function_section(base: i32, offset: i32, func_count: i32) -> i32 {
     out
 }
 
+fn compiler_memory_pages() -> i32 {
+    64
+}
+
 fn emit_memory_section(base: i32, offset: i32) -> i32 {
     let mut out: i32 = offset;
     out = write_byte(base, out, 5);
-    let payload_size: i32 = leb_u32_len(1) + 1 + leb_u32_len(16) + leb_u32_len(16);
+    let pages: i32 = compiler_memory_pages();
+    let payload_size: i32 = leb_u32_len(1) + 1 + leb_u32_len(pages) + leb_u32_len(pages);
     out = write_u32_leb(base, out, payload_size);
     out = write_u32_leb(base, out, 1);
     out = write_byte(base, out, 1);
-    out = write_u32_leb(base, out, 16);
-    out = write_u32_leb(base, out, 16);
+    out = write_u32_leb(base, out, pages);
+    out = write_u32_leb(base, out, pages);
     out
 }
 
@@ -5363,7 +5372,7 @@ fn compile(input_ptr: i32, input_len: i32, out_ptr: i32) -> i32 {
 
     initialize_layout(out_ptr);
 
-    let ast_base: i32 = ast_program_base(out_ptr);
+    let ast_base: i32 = ast_program_base(out_ptr, input_len);
     ast_reset(ast_base);
 
     let func_count: i32 = parse_program(input_ptr, input_len, ast_base);

--- a/tests/ast_compiler.rs
+++ b/tests/ast_compiler.rs
@@ -1,12 +1,17 @@
 #[path = "wasm_harness.rs"]
 mod wasm_harness;
 
-use wasm_harness::run_wasm_main;
+use wasm_harness::{run_wasm_main, CompilerInstance, DEFAULT_OUTPUT_STRIDE};
 
 #[path = "ast_compiler_helpers.rs"]
 mod ast_compiler_helpers;
 
-use ast_compiler_helpers::{compile_with_ast_compiler, try_compile_with_ast_compiler};
+use ast_compiler_helpers::{
+    ast_compiler_source,
+    ast_compiler_wasm,
+    compile_with_ast_compiler,
+    try_compile_with_ast_compiler,
+};
 
 #[test]
 fn ast_compiler_emits_constant_main() {
@@ -1109,4 +1114,19 @@ fn main() -> i32 {
     let error = try_compile_with_ast_compiler(source)
         .expect_err("ast compiler should reject blocks without a final expression");
     assert!(error.produced_len <= 0);
+}
+
+#[test]
+fn ast_compiler_compiles_its_source_once() {
+    let mut compiler = CompilerInstance::new(ast_compiler_wasm());
+    let source = ast_compiler_source();
+
+    let wasm = compiler
+        .compile_at(0, source.len() as i32, source)
+        .expect("ast compiler should compile its own source");
+
+    assert!(
+        wasm.len() > DEFAULT_OUTPUT_STRIDE as usize,
+        "self-compiled output should be larger than the default stride",
+    );
 }

--- a/tests/wasm_harness.rs
+++ b/tests/wasm_harness.rs
@@ -223,12 +223,12 @@ pub fn run_wasm_main(engine: &Engine, wasm: &[u8]) -> i32 {
     let memory: Memory = instance
         .get_memory(&mut store, "memory")
         .expect("compiled module should export memory");
-    assert_eq!(
+    assert!(
         memory
             .current_pages(&store)
             .to_bytes()
-            .expect("memory pages to bytes"),
-        1048576
+            .expect("memory pages to bytes")
+            >= 1_048_576
     );
 
     let main_fn: TypedFunc<(), i32> = instance


### PR DESCRIPTION
## Summary
- base the AST scratch region after a dynamically sized output reserve so emitted code no longer overwrites parsed data
- raise the compiler module's memory allocation via a dedicated helper for the new layout
- add a regression test that self-compiles the AST compiler and relax the harness' memory size assertion

## Testing
- cargo test --test ast_compiler -- --nocapture
- cargo test --test entry_point -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68e388cf922c83299d9df72c5a101f7e