### PR TITLE
Fix AST compiler function section sizing and add regression test

### DIFF
--- a/compiler/ast_compiler.bp
+++ b/compiler/ast_compiler.bp
@@ -5091,12 +5091,21 @@ fn emit_type_section(base: i32, offset: i32, ast_base: i32, func_count: i32) -> 
 }
 
 fn emit_function_section(base: i32, offset: i32, func_count: i32) -> i32 {
+    let mut payload_size: i32 = leb_u32_len(func_count);
+    let mut idx: i32 = 0;
+    loop {
+        if idx >= func_count {
+            break;
+        };
+        payload_size = payload_size + leb_u32_len(idx);
+        idx = idx + 1;
+    };
+
     let mut out: i32 = offset;
     out = write_byte(base, out, 3);
-    let payload_size: i32 = leb_u32_len(func_count) + func_count;
     out = write_u32_leb(base, out, payload_size);
     out = write_u32_leb(base, out, func_count);
-    let mut idx: i32 = 0;
+    idx = 0;
     loop {
         if idx >= func_count {
             break;


### PR DESCRIPTION
## Summary
- fix the AST compiler function section payload sizing to account for multi-byte indices
- add a regression test that compiles a program with many helper functions to ensure valid output

## Testing
- cargo test --test ast_compiler ast_compiler_emits_function_section_with_multibyte_type_indices -- --nocapture
- cargo test --test bootstrap_ast ast_compiler_compiler_bootstraps -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68e394b62dec832993bae9b271427048