### PR TITLE
Add character literal support

### DIFF
--- a/compiler/ast_compiler.bp
+++ b/compiler/ast_compiler.bp
@@ -1698,6 +1698,67 @@ fn parse_i32_literal(base: i32, len: i32, offset: i32, out_value_ptr: i32) -> i3
     idx
 }
 
+fn parse_char_literal(base: i32, len: i32, offset: i32, out_value_ptr: i32) -> i32 {
+    if offset >= len {
+        return -1;
+    };
+    let quote: i32 = load_u8(base + offset);
+    if quote != 39 {
+        return -1;
+    };
+    let mut idx: i32 = offset + 1;
+    if idx >= len {
+        return -1;
+    };
+    let mut value: i32 = load_u8(base + idx);
+    if value == 92 {
+        idx = idx + 1;
+        if idx >= len {
+            return -1;
+        };
+        let escape: i32 = load_u8(base + idx);
+        value = if escape == 110 {
+            10
+        } else {
+            if escape == 114 {
+                13
+            } else {
+                if escape == 116 {
+                    9
+                } else {
+                    if escape == 48 {
+                        0
+                    } else {
+                        if escape == 92 {
+                            92
+                        } else {
+                            if escape == 39 {
+                                39
+                            } else {
+                                return -1;
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    } else {
+        if value == 10 || value == 13 {
+            return -1;
+        };
+    };
+    idx = idx + 1;
+    if idx >= len {
+        return -1;
+    };
+    let closing: i32 = load_u8(base + idx);
+    if closing != 39 {
+        return -1;
+    };
+    store_i32(out_value_ptr, value);
+    idx + 1
+}
+
 fn word_size() -> i32 {
     4
 }
@@ -2337,6 +2398,17 @@ fn parse_basic_expression(
             return -1;
         };
         return skip_whitespace(base, len, paren_cursor);
+    };
+    if first_byte == 39 {
+        let next_cursor: i32 = parse_char_literal(base, len, cursor, literal_ptr);
+        if next_cursor < 0 {
+            return -1;
+        };
+        let value: i32 = load_i32(literal_ptr);
+        store_i32(out_kind_ptr, 0);
+        store_i32(out_data0_ptr, value);
+        store_i32(out_data1_ptr, 0);
+        return skip_whitespace(base, len, next_cursor);
     };
     if first_byte == 45 || is_digit(first_byte) {
         let next_cursor: i32 = parse_i32_literal(base, len, cursor, literal_ptr);

--- a/tests/characters.rs
+++ b/tests/characters.rs
@@ -1,0 +1,81 @@
+#[path = "ast_compiler_helpers.rs"]
+mod ast_compiler_helpers;
+
+use ast_compiler_helpers::{compile_with_ast_compiler, try_compile_with_ast_compiler};
+use wasmi::{Engine, Linker, Module, Store, TypedFunc};
+
+#[test]
+fn character_literals_execute() {
+    let source = r#"
+fn char_math() -> i32 {
+    let letter: i32 = 'a';
+    let newline: i32 = '\n';
+    let quote: i32 = '\'';
+    letter + newline + quote
+}
+
+fn slash() -> i32 {
+    '\\'
+}
+
+fn main() -> i32 {
+    if '\\' == 92 {
+        char_math() - '\\' + 'A'
+    } else {
+        0
+    }
+}
+"#;
+
+    let wasm = compile_with_ast_compiler(source);
+
+    let engine = Engine::default();
+    let mut wasm_reader = wasm.as_slice();
+    let module = Module::new(&engine, &mut wasm_reader).expect("failed to create module");
+    let mut store = Store::new(&engine, ());
+    let linker = Linker::new(&engine);
+    let instance = linker
+        .instantiate(&mut store, &module)
+        .expect("failed to instantiate module")
+        .start(&mut store)
+        .expect("failed to start module");
+
+    let char_math: TypedFunc<(), i32> = instance
+        .get_typed_func(&mut store, "char_math")
+        .expect("expected exported char_math");
+    let slash: TypedFunc<(), i32> = instance
+        .get_typed_func(&mut store, "slash")
+        .expect("expected exported slash");
+    let main: TypedFunc<(), i32> = instance
+        .get_typed_func(&mut store, "main")
+        .expect("expected exported main");
+
+    let char_math_result = char_math
+        .call(&mut store, ())
+        .expect("failed to execute char_math");
+    assert_eq!(char_math_result, 146);
+
+    let slash_result = slash
+        .call(&mut store, ())
+        .expect("failed to execute slash");
+    assert_eq!(slash_result, 92);
+
+    let main_result = main
+        .call(&mut store, ())
+        .expect("failed to execute main");
+    assert_eq!(main_result, 119);
+}
+
+#[test]
+fn invalid_character_literals_are_rejected() {
+    let source = r#"
+fn main() -> i32 {
+    let bad: i32 = 'ab';
+    bad
+}
+"#;
+
+    let error = try_compile_with_ast_compiler(source)
+        .expect_err("expected invalid character literal to be rejected");
+    assert!(error.produced_len <= 0);
+}


### PR DESCRIPTION
## Summary
- add parsing support for character literals, including common escape sequences
- emit character literals as i32 expressions in the AST
- cover valid and invalid character literal cases with new integration tests

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e446866ef88329825c801a84c1dda0