### PR TITLE
Add integer type table and improve type parsing

### DIFF
--- a/compiler/ast_compiler.bp
+++ b/compiler/ast_compiler.bp
@@ -1619,43 +1619,168 @@ fn parse_block_expression_body(
     idx
 }
 
+fn builtin_type_id_i32() -> i32 {
+    0
+}
+
+fn builtin_type_id_bool() -> i32 {
+    1
+}
+
+fn builtin_type_id_i8() -> i32 {
+    2
+}
+
+fn builtin_type_id_i16() -> i32 {
+    3
+}
+
+fn builtin_type_id_i64() -> i32 {
+    4
+}
+
+fn builtin_type_id_u8() -> i32 {
+    5
+}
+
+fn builtin_type_id_u16() -> i32 {
+    6
+}
+
+fn builtin_type_id_u32() -> i32 {
+    7
+}
+
+fn builtin_type_id_u64() -> i32 {
+    8
+}
+
+fn builtin_integer_variant_count() -> i32 {
+    4
+}
+
+fn builtin_integer_variant_width(index: i32) -> i32 {
+    if index == 0 {
+        return 8;
+    };
+    if index == 1 {
+        return 16;
+    };
+    if index == 2 {
+        return 32;
+    };
+    64
+}
+
+fn builtin_signed_integer_type_id_for_variant(index: i32) -> i32 {
+    if index == 0 {
+        return builtin_type_id_i8();
+    };
+    if index == 1 {
+        return builtin_type_id_i16();
+    };
+    if index == 2 {
+        return builtin_type_id_i32();
+    };
+    if index == 3 {
+        return builtin_type_id_i64();
+    };
+    -1
+}
+
+fn builtin_unsigned_integer_type_id_for_variant(index: i32) -> i32 {
+    if index == 0 {
+        return builtin_type_id_u8();
+    };
+    if index == 1 {
+        return builtin_type_id_u16();
+    };
+    if index == 2 {
+        return builtin_type_id_u32();
+    };
+    if index == 3 {
+        return builtin_type_id_u64();
+    };
+    -1
+}
+
+fn builtin_integer_type_keyword_to_id(base: i32, start: i32, ident_len: i32) -> i32 {
+    if ident_len <= 1 {
+        return -1;
+    };
+    let first: i32 = load_u8(base + start);
+    if first != 'i' && first != 'u' {
+        return -1;
+    };
+    let mut idx: i32 = 1;
+    let mut width: i32 = 0;
+    loop {
+        if idx >= ident_len {
+            break;
+        };
+        let digit: i32 = load_u8(base + start + idx);
+        if !is_digit(digit) {
+            return -1;
+        };
+        width = width * 10 + (digit - '0');
+        idx = idx + 1;
+    };
+    let variant_count: i32 = builtin_integer_variant_count();
+    let mut variant_index: i32 = 0;
+    loop {
+        if variant_index >= variant_count {
+            break;
+        };
+        let expected_width: i32 = builtin_integer_variant_width(variant_index);
+        if expected_width == width {
+            if first == 'i' {
+                return builtin_signed_integer_type_id_for_variant(variant_index);
+            };
+            return builtin_unsigned_integer_type_id_for_variant(variant_index);
+        };
+        variant_index = variant_index + 1;
+    };
+    -1
+}
+
 fn parse_type(base: i32, len: i32, offset: i32, out_type_ptr: i32) -> i32 {
     if offset >= len {
         return -1;
     };
-    if offset + 3 <= len {
-        let byte0: i32 = load_u8(base + offset);
-        let byte1: i32 = load_u8(base + offset + 1);
-        let byte2: i32 = load_u8(base + offset + 2);
-        if byte0 == 'i' && byte1 == '3' && byte2 == '2' {
-            let next: i32 = offset + 3;
-            if next < len {
-                let after: i32 = load_u8(base + next);
-                if is_identifier_continue(after) {
-                    return -1;
-                };
-            };
-            if out_type_ptr >= 0 {
-                store_i32(out_type_ptr, 0);
-            };
-            return next;
-        };
+    let first: i32 = load_u8(base + offset);
+    if !is_identifier_start(first) {
+        return -1;
     };
-    if offset + 4 <= len {
+    let mut next: i32 = offset + 1;
+    loop {
+        if next >= len {
+            break;
+        };
+        let byte: i32 = load_u8(base + next);
+        if !is_identifier_continue(byte) {
+            break;
+        };
+        next = next + 1;
+    };
+    let ident_len: i32 = next - offset;
+    if ident_len <= 0 {
+        return -1;
+    };
+    let type_id: i32 = builtin_integer_type_keyword_to_id(base, offset, ident_len);
+    if type_id >= 0 {
+        if out_type_ptr >= 0 {
+            store_i32(out_type_ptr, type_id);
+        };
+        return next;
+    };
+    if ident_len == 4 {
         let b: i32 = load_u8(base + offset);
-        let o: i32 = load_u8(base + offset + 1);
-        let o2: i32 = load_u8(base + offset + 2);
+        let o0: i32 = load_u8(base + offset + 1);
+        let o1: i32 = load_u8(base + offset + 2);
         let l: i32 = load_u8(base + offset + 3);
-        if b == 'b' && o == 'o' && o2 == 'o' && l == 'l' {
-            let next: i32 = offset + 4;
-            if next < len {
-                let after: i32 = load_u8(base + next);
-                if is_identifier_continue(after) {
-                    return -1;
-                };
-            };
+        if b == 'b' && o0 == 'o' && o1 == 'o' && l == 'l' {
             if out_type_ptr >= 0 {
-                store_i32(out_type_ptr, 1);
+                store_i32(out_type_ptr, builtin_type_id_bool());
             };
             return next;
         };
@@ -1791,6 +1916,22 @@ fn type_entry_size() -> i32 {
     16
 }
 
+fn type_entry_type_id_offset() -> i32 {
+    0
+}
+
+fn type_entry_name_ptr_offset() -> i32 {
+    4
+}
+
+fn type_entry_name_len_offset() -> i32 {
+    8
+}
+
+fn type_entry_extra_offset() -> i32 {
+    12
+}
+
 fn scratch_types_capacity() -> i32 {
     2048
 }
@@ -1829,6 +1970,14 @@ fn scratch_types_count_ptr(out_ptr: i32) -> i32 {
 
 fn scratch_types_base(out_ptr: i32) -> i32 {
     out_ptr + scratch_types_base_offset()
+}
+
+fn scratch_type_entry_ptr(out_ptr: i32, index: i32) -> i32 {
+    scratch_types_base(out_ptr) + index * type_entry_size()
+}
+
+fn scratch_type_entry_type_id_ptr(out_ptr: i32, index: i32) -> i32 {
+    scratch_type_entry_ptr(out_ptr, index) + type_entry_type_id_offset()
 }
 
 fn ast_max_functions() -> i32 {


### PR DESCRIPTION
## Summary
- add shared builtin integer type identifier helpers and a keyword mapper near the type parser
- update `parse_type` to validate identifiers early and emit the new builtin IDs
- expose scratch type entry offsets so alias bookkeeping can store expanded IDs

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e45d5e75e08329aa471c283c95a9f6