### PR TITLE
Refactor compiler conditionals to use else if

### DIFF
--- a/compiler/ast_compiler.bp
+++ b/compiler/ast_compiler.bp
@@ -1902,33 +1902,21 @@ fn parse_char_literal(base: i32, len: i32, offset: i32, out_value_ptr: i32) -> i
         let escape: i32 = load_u8(base + idx);
         value = if escape == 'n' {
             '\n'
+        } else if escape == 'r' {
+            '\r'
+        } else if escape == 't' {
+            '\t'
+        } else if escape == '0' {
+            '\0'
+        } else if escape == '\\' {
+            '\\'
+        } else if escape == '\'' {
+            '\''
         } else {
-            if escape == 'r' {
-                '\r'
-            } else {
-                if escape == 't' {
-                    '\t'
-                } else {
-                    if escape == '0' {
-                        '\0'
-                    } else {
-                        if escape == '\\' {
-                            '\\'
-                        } else {
-                            if escape == '\'' {
-                                '\''
-                            } else {
-                                return -1;
-                            }
-                        }
-                    }
-                }
-            }
-        };
-    } else {
-        if value == '\n' || value == '\r' {
             return -1;
         };
+    } else if value == '\n' || value == '\r' {
+        return -1;
     };
     idx = idx + 1;
     if idx >= len {
@@ -2992,12 +2980,10 @@ fn parse_basic_expression(
                     let arg_index: i32 = load_i32(args_list_ptr);
                     let expr_index: i32 = if intrinsic_kind == intrinsic_kind_load_u8() {
                         ast_expr_alloc_load_u8(ast_base, arg_index)
+                    } else if intrinsic_kind == intrinsic_kind_load_u16() {
+                        ast_expr_alloc_load_u16(ast_base, arg_index)
                     } else {
-                        if intrinsic_kind == intrinsic_kind_load_u16() {
-                            ast_expr_alloc_load_u16(ast_base, arg_index)
-                        } else {
-                            ast_expr_alloc_load_i32(ast_base, arg_index)
-                        }
+                        ast_expr_alloc_load_i32(ast_base, arg_index)
                     };
                     if expr_index < 0 {
                         return -1;
@@ -3018,12 +3004,10 @@ fn parse_basic_expression(
                     let value_index: i32 = load_i32(args_list_ptr + 4);
                     let expr_index: i32 = if intrinsic_kind == intrinsic_kind_store_u8() {
                         ast_expr_alloc_store_u8(ast_base, ptr_index, value_index)
+                    } else if intrinsic_kind == intrinsic_kind_store_u16() {
+                        ast_expr_alloc_store_u16(ast_base, ptr_index, value_index)
                     } else {
-                        if intrinsic_kind == intrinsic_kind_store_u16() {
-                            ast_expr_alloc_store_u16(ast_base, ptr_index, value_index)
-                        } else {
-                            ast_expr_alloc_store_i32(ast_base, ptr_index, value_index)
-                        }
+                        ast_expr_alloc_store_i32(ast_base, ptr_index, value_index)
                     };
                     if expr_index < 0 {
                         return -1;
@@ -3439,12 +3423,10 @@ fn parse_shift_expression(
         let mut op_kind: i32 = -1;
         if first == '<' && second == '<' {
             op_kind = 0;
+        } else if first == '>' && second == '>' {
+            op_kind = 1;
         } else {
-            if first == '>' && second == '>' {
-                op_kind = 1;
-            } else {
-                break;
-            };
+            break;
         };
 
         current_cursor = skip_whitespace(base, len, current_cursor + 2);
@@ -3557,31 +3539,27 @@ fn parse_relational_expression(
                 if next == '=' {
                     relation_op = 2;
                     consume = 2;
+                } else if next == '<' {
+                    return -1;
                 } else {
-                    if next == '<' {
-                        return -1;
-                    };
                     relation_op = 0;
                 };
             } else {
                 relation_op = 0;
             };
-        } else {
-            if operator_byte == '>' {
-                if current_cursor + 1 < len {
-                    let next: i32 = load_u8(base + current_cursor + 1);
-                    if next == '=' {
-                        relation_op = 3;
-                        consume = 2;
-                    } else {
-                        if next == '>' {
-                            return -1;
-                        };
-                        relation_op = 1;
-                    };
+        } else if operator_byte == '>' {
+            if current_cursor + 1 < len {
+                let next: i32 = load_u8(base + current_cursor + 1);
+                if next == '=' {
+                    relation_op = 3;
+                    consume = 2;
+                } else if next == '>' {
+                    return -1;
                 } else {
                     relation_op = 1;
                 };
+            } else {
+                relation_op = 1;
             };
         };
 
@@ -3629,16 +3607,12 @@ fn parse_relational_expression(
 
         let new_index: i32 = if relation_op == 0 {
             ast_expr_alloc_lt(ast_base, left_index, right_index)
+        } else if relation_op == 1 {
+            ast_expr_alloc_gt(ast_base, left_index, right_index)
+        } else if relation_op == 2 {
+            ast_expr_alloc_le(ast_base, left_index, right_index)
         } else {
-            if relation_op == 1 {
-                ast_expr_alloc_gt(ast_base, left_index, right_index)
-            } else {
-                if relation_op == 2 {
-                    ast_expr_alloc_le(ast_base, left_index, right_index)
-                } else {
-                    ast_expr_alloc_ge(ast_base, left_index, right_index)
-                }
-            }
+            ast_expr_alloc_ge(ast_base, left_index, right_index)
         };
         if new_index < 0 {
             return -1;
@@ -3705,15 +3679,13 @@ fn parse_equality_expression(
                 break;
             };
             equality_op = 0;
-        } else {
-            if operator_byte == '!' {
-                if next_byte != '=' {
-                    break;
-                };
-                equality_op = 1;
-            } else {
+        } else if operator_byte == '!' {
+            if next_byte != '=' {
                 break;
             };
+            equality_op = 1;
+        } else {
+            break;
         };
 
         current_cursor = current_cursor + 2;
@@ -4617,13 +4589,11 @@ fn validate_program(ast_base: i32, func_count: i32) -> i32 {
             if resolve_call_metadata(ast_base, metadata_ptr, func_count) < 0 {
                 return -1;
             };
-        } else {
-            if body_kind == 2 {
-                let expr_index: i32 = load_i32(entry_ptr + 16);
-                if resolve_expression(ast_base, expr_index, func_count) < 0 {
-                    return -1;
-                };
-                };
+        } else if body_kind == 2 {
+            let expr_index: i32 = load_i32(entry_ptr + 16);
+            if resolve_expression(ast_base, expr_index, func_count) < 0 {
+                return -1;
+            };
         };
         idx = idx + 1;
     };
@@ -5292,101 +5262,94 @@ fn collect_local_counts_from_expression(
             local_counts_pack(1, 0)
         };
         local_counts_add(total, declaration_counts)
+    } else if kind == 10 {
+        let value_index: i32 = load_i32(entry_ptr + 8);
+        return collect_local_counts_from_expression(
+            ast_base,
+            value_index,
+            param_count,
+            locals_end,
+        );
+    } else if kind == 11 {
+        let first_index: i32 = load_i32(entry_ptr + 4);
+        let then_index: i32 = load_i32(entry_ptr + 8);
+        let first_counts: i32 = collect_local_counts_from_expression(
+            ast_base,
+            first_index,
+            param_count,
+            locals_end,
+        );
+        if first_counts < 0 {
+            return -1;
+        };
+        let then_counts: i32 = collect_local_counts_from_expression(
+            ast_base,
+            then_index,
+            param_count,
+            locals_end,
+        );
+        if then_counts < 0 {
+            return -1;
+        };
+        return local_counts_add(first_counts, then_counts);
+    } else if kind == 12 {
+        let body_index: i32 = load_i32(entry_ptr + 4);
+        return collect_local_counts_from_expression(
+            ast_base,
+            body_index,
+            param_count,
+            locals_end,
+        );
+    } else if kind == 13 {
+        let value_index: i32 = load_i32(entry_ptr + 8);
+        if value_index >= 0 {
+            return collect_local_counts_from_expression(
+                ast_base,
+                value_index,
+                param_count,
+                locals_end,
+            );
+        };
+        return 0;
+    } else if kind == 22 || kind == 23 {
+        let value_index: i32 = load_i32(entry_ptr + 4);
+        return collect_local_counts_from_expression(
+            ast_base,
+            value_index,
+            param_count,
+            locals_end,
+        );
+    } else if kind == 29 || kind == 30 || kind == 31 {
+        let ptr_index: i32 = load_i32(entry_ptr + 4);
+        return collect_local_counts_from_expression(
+            ast_base,
+            ptr_index,
+            param_count,
+            locals_end,
+        );
+    } else if kind == 32 || kind == 33 || kind == 34 {
+        let ptr_index: i32 = load_i32(entry_ptr + 4);
+        let value_index: i32 = load_i32(entry_ptr + 8);
+        let ptr_counts: i32 = collect_local_counts_from_expression(
+            ast_base,
+            ptr_index,
+            param_count,
+            locals_end,
+        );
+        if ptr_counts < 0 {
+            return -1;
+        };
+        let value_counts: i32 = collect_local_counts_from_expression(
+            ast_base,
+            value_index,
+            param_count,
+            locals_end,
+        );
+        if value_counts < 0 {
+            return -1;
+        };
+        return local_counts_add(ptr_counts, value_counts);
     } else {
-        if kind == 10 {
-            let value_index: i32 = load_i32(entry_ptr + 8);
-            return collect_local_counts_from_expression(
-                ast_base,
-                value_index,
-                param_count,
-                locals_end,
-            );
-        };
-        if kind == 11 {
-            let first_index: i32 = load_i32(entry_ptr + 4);
-            let then_index: i32 = load_i32(entry_ptr + 8);
-            let first_counts: i32 = collect_local_counts_from_expression(
-                ast_base,
-                first_index,
-                param_count,
-                locals_end,
-            );
-            if first_counts < 0 {
-                return -1;
-            };
-            let then_counts: i32 = collect_local_counts_from_expression(
-                ast_base,
-                then_index,
-                param_count,
-                locals_end,
-            );
-            if then_counts < 0 {
-                return -1;
-            };
-            return local_counts_add(first_counts, then_counts);
-        };
-        if kind == 12 {
-            let body_index: i32 = load_i32(entry_ptr + 4);
-            return collect_local_counts_from_expression(
-                ast_base,
-                body_index,
-                param_count,
-                locals_end,
-            );
-        };
-        if kind == 13 {
-            let value_index: i32 = load_i32(entry_ptr + 8);
-            if value_index >= 0 {
-                return collect_local_counts_from_expression(
-                    ast_base,
-                    value_index,
-                    param_count,
-                    locals_end,
-                );
-            };
-            return 0;
-        };
-        if kind == 22 || kind == 23 {
-            let value_index: i32 = load_i32(entry_ptr + 4);
-            return collect_local_counts_from_expression(
-                ast_base,
-                value_index,
-                param_count,
-                locals_end,
-            );
-        };
-        if kind == 29 || kind == 30 || kind == 31 {
-            let ptr_index: i32 = load_i32(entry_ptr + 4);
-            return collect_local_counts_from_expression(
-                ast_base,
-                ptr_index,
-                param_count,
-                locals_end,
-            );
-        };
-        if kind == 32 || kind == 33 || kind == 34 {
-            let ptr_index: i32 = load_i32(entry_ptr + 4);
-            let value_index: i32 = load_i32(entry_ptr + 8);
-            let ptr_counts: i32 = collect_local_counts_from_expression(
-                ast_base,
-                ptr_index,
-                param_count,
-                locals_end,
-            );
-            if ptr_counts < 0 {
-                return -1;
-            };
-            let value_counts: i32 = collect_local_counts_from_expression(
-                ast_base,
-                value_index,
-                param_count,
-                locals_end,
-            );
-            if value_counts < 0 {
-                return -1;
-            };
-            return local_counts_add(ptr_counts, value_counts);
-        };
         0
     }
 }
@@ -5519,12 +5482,10 @@ fn expression_code_size(ast_base: i32, expr_index: i32) -> i32 {
         };
         let align: i32 = if kind == 29 {
             0
+        } else if kind == 30 {
+            1
         } else {
-            if kind == 30 {
-                1
-            } else {
-                2
-            }
+            2
         };
         return ptr_size + 1 + leb_u32_len(align) + leb_u32_len(0);
     };
@@ -5541,12 +5502,10 @@ fn expression_code_size(ast_base: i32, expr_index: i32) -> i32 {
         };
         let align: i32 = if kind == 32 {
             0
+        } else if kind == 33 {
+            1
         } else {
-            if kind == 33 {
-                1
-            } else {
-                2
-            }
+            2
         };
         return ptr_size
             + value_size
@@ -5772,21 +5731,17 @@ fn emit_expression(base: i32, offset: i32, ast_base: i32, expr_index: i32) -> i3
         };
         let opcode: i32 = if kind == 29 {
             45
+        } else if kind == 30 {
+            47
         } else {
-            if kind == 30 {
-                47
-            } else {
-                40
-            }
+            40
         };
         let align: i32 = if kind == 29 {
             0
+        } else if kind == 30 {
+            1
         } else {
-            if kind == 30 {
-                1
-            } else {
-                2
-            }
+            2
         };
         out = write_byte(base, out, opcode);
         out = write_u32_leb(base, out, align);
@@ -5806,21 +5761,17 @@ fn emit_expression(base: i32, offset: i32, ast_base: i32, expr_index: i32) -> i3
         };
         let opcode: i32 = if kind == 32 {
             58
+        } else if kind == 33 {
+            59
         } else {
-            if kind == 33 {
-                59
-            } else {
-                54
-            }
+            54
         };
         let align: i32 = if kind == 32 {
             0
+        } else if kind == 33 {
+            1
         } else {
-            if kind == 33 {
-                1
-            } else {
-                2
-            }
+            2
         };
         out = write_byte(base, out, opcode);
         out = write_u32_leb(base, out, align);
@@ -5866,80 +5817,66 @@ fn emit_expression(base: i32, offset: i32, ast_base: i32, expr_index: i32) -> i3
         let is_signed: bool = type_id_is_signed_integer(op_type);
         let opcode: i32 = if kind == 2 {
             if is_i64 { 124 } else { 106 }
-        } else {
-            if kind == 3 {
-                if is_i64 { 125 } else { 107 }
+        } else if kind == 3 {
+            if is_i64 { 125 } else { 107 }
+        } else if kind == 4 {
+            if is_i64 { 126 } else { 108 }
+        } else if kind == 5 {
+            if is_i64 {
+                if is_signed { 127 } else { 128 }
+            } else if is_signed {
+                109
             } else {
-                if kind == 4 {
-                    if is_i64 { 126 } else { 108 }
-                } else {
-                    if kind == 5 {
-                        if is_i64 {
-                            if is_signed { 127 } else { 128 }
-                        } else {
-                            if is_signed { 109 } else { 110 }
-                        }
-                    } else {
-                        if kind == 14 {
-                            if is_i64 { 81 } else { 70 }
-                        } else {
-                            if kind == 15 {
-                                if is_i64 { 82 } else { 71 }
-                            } else {
-                                if kind == 16 {
-                                    if is_i64 {
-                                        if is_signed { 83 } else { 84 }
-                                    } else {
-                                        if is_signed { 72 } else { 73 }
-                                    }
-                                } else {
-                                    if kind == 17 {
-                                        if is_i64 {
-                                            if is_signed { 85 } else { 86 }
-                                        } else {
-                                            if is_signed { 74 } else { 75 }
-                                        }
-                                    } else {
-                                        if kind == 18 {
-                                            if is_i64 {
-                                                if is_signed { 87 } else { 88 }
-                                            } else {
-                                                if is_signed { 76 } else { 77 }
-                                            }
-                                        } else {
-                                            if kind == 19 {
-                                                if is_i64 {
-                                                    if is_signed { 89 } else { 90 }
-                                                } else {
-                                                    if is_signed { 78 } else { 79 }
-                                                }
-                                            } else {
-                                                if kind == 25 {
-                                                    if is_i64 { 132 } else { 114 }
-                                                } else {
-                                                    if kind == 26 {
-                                                        if is_i64 { 131 } else { 113 }
-                                                    } else {
-                                                        if kind == 27 {
-                                                            if is_i64 { 134 } else { 116 }
-                                                        } else {
-                                                            if is_i64 {
-                                                                if is_signed { 135 } else { 136 }
-                                                            } else {
-                                                                if is_signed { 117 } else { 118 }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                110
             }
+        } else if kind == 14 {
+            if is_i64 { 81 } else { 70 }
+        } else if kind == 15 {
+            if is_i64 { 82 } else { 71 }
+        } else if kind == 16 {
+            if is_i64 {
+                if is_signed { 83 } else { 84 }
+            } else if is_signed {
+                72
+            } else {
+                73
+            }
+        } else if kind == 17 {
+            if is_i64 {
+                if is_signed { 85 } else { 86 }
+            } else if is_signed {
+                74
+            } else {
+                75
+            }
+        } else if kind == 18 {
+            if is_i64 {
+                if is_signed { 87 } else { 88 }
+            } else if is_signed {
+                76
+            } else {
+                77
+            }
+        } else if kind == 19 {
+            if is_i64 {
+                if is_signed { 89 } else { 90 }
+            } else if is_signed {
+                78
+            } else {
+                79
+            }
+        } else if kind == 25 {
+            if is_i64 { 132 } else { 114 }
+        } else if kind == 26 {
+            if is_i64 { 131 } else { 113 }
+        } else if kind == 27 {
+            if is_i64 { 134 } else { 116 }
+        } else if is_i64 {
+            if is_signed { 135 } else { 136 }
+        } else if is_signed {
+            117
+        } else {
+            118
         };
         out = write_byte(base, out, opcode);
         return out;
@@ -6331,41 +6268,39 @@ fn emit_code_section(base: i32, offset: i32, ast_base: i32, func_count: i32) -> 
         if body_kind == 0 {
             let literal_value: i32 = load_i32(entry_ptr + 16);
             body_size = locals_decl_size + 1 + leb_i32_len(literal_value) + 1;
-        } else {
-            if body_kind == 1 {
-                let metadata_ptr: i32 = load_i32(entry_ptr + 16);
-                if metadata_ptr < 0 {
-                    return -1;
-                };
-                let callee_index: i32 = load_i32(call_metadata_callee_index_ptr(metadata_ptr));
-                if callee_index < 0 {
-                    return -1;
-                };
-                let arg_count: i32 = call_metadata_arg_count(metadata_ptr);
-                let args_base: i32 = call_metadata_args_base(metadata_ptr);
-                let mut args_size: i32 = 0;
-                let mut arg_idx: i32 = 0;
-                loop {
-                    if arg_idx >= arg_count {
-                        break;
-                    };
-                    let arg_expr_index: i32 = load_i32(args_base + arg_idx * 4);
-                    let arg_size: i32 = expression_code_size(ast_base, arg_expr_index);
-                    if arg_size < 0 {
-                        return -1;
-                    };
-                    args_size = args_size + arg_size;
-                    arg_idx = arg_idx + 1;
-                };
-                body_size = locals_decl_size + args_size + 1 + leb_u32_len(callee_index) + 1;
-            } else {
-                let expr_index: i32 = load_i32(entry_ptr + 16);
-                let expr_size: i32 = expression_code_size(ast_base, expr_index);
-                if expr_size < 0 {
-                    return -1;
-                };
-                body_size = locals_decl_size + expr_size + 1;
+        } else if body_kind == 1 {
+            let metadata_ptr: i32 = load_i32(entry_ptr + 16);
+            if metadata_ptr < 0 {
+                return -1;
             };
+            let callee_index: i32 = load_i32(call_metadata_callee_index_ptr(metadata_ptr));
+            if callee_index < 0 {
+                return -1;
+            };
+            let arg_count: i32 = call_metadata_arg_count(metadata_ptr);
+            let args_base: i32 = call_metadata_args_base(metadata_ptr);
+            let mut args_size: i32 = 0;
+            let mut arg_idx: i32 = 0;
+            loop {
+                if arg_idx >= arg_count {
+                    break;
+                };
+                let arg_expr_index: i32 = load_i32(args_base + arg_idx * 4);
+                let arg_size: i32 = expression_code_size(ast_base, arg_expr_index);
+                if arg_size < 0 {
+                    return -1;
+                };
+                args_size = args_size + arg_size;
+                arg_idx = arg_idx + 1;
+            };
+            body_size = locals_decl_size + args_size + 1 + leb_u32_len(callee_index) + 1;
+        } else {
+            let expr_index: i32 = load_i32(entry_ptr + 16);
+            let expr_size: i32 = expression_code_size(ast_base, expr_index);
+            if expr_size < 0 {
+                return -1;
+            };
+            body_size = locals_decl_size + expr_size + 1;
         };
         payload_size = payload_size + leb_u32_len(body_size) + body_size;
         idx = idx + 1;
@@ -6441,89 +6376,87 @@ fn emit_code_section(base: i32, offset: i32, ast_base: i32, func_count: i32) -> 
             out = write_byte(base, out, 65);
             out = write_i32_leb(base, out, literal_value);
             out = write_byte(base, out, 11);
-        } else {
-            if body_kind == 1 {
-                let metadata_ptr: i32 = load_i32(entry_ptr + 16);
-                if metadata_ptr < 0 {
+        } else if body_kind == 1 {
+            let metadata_ptr: i32 = load_i32(entry_ptr + 16);
+            if metadata_ptr < 0 {
+                return -1;
+            };
+            let callee_index: i32 = load_i32(call_metadata_callee_index_ptr(metadata_ptr));
+            if callee_index < 0 {
+                return -1;
+            };
+            let arg_count: i32 = call_metadata_arg_count(metadata_ptr);
+            let args_base: i32 = call_metadata_args_base(metadata_ptr);
+            let mut args_size: i32 = 0;
+            let mut arg_idx: i32 = 0;
+            loop {
+                if arg_idx >= arg_count {
+                    break;
+                };
+                let arg_expr_index: i32 = load_i32(args_base + arg_idx * 4);
+                let arg_size: i32 = expression_code_size(ast_base, arg_expr_index);
+                if arg_size < 0 {
                     return -1;
                 };
-                let callee_index: i32 = load_i32(call_metadata_callee_index_ptr(metadata_ptr));
-                if callee_index < 0 {
-                    return -1;
+                args_size = args_size + arg_size;
+                arg_idx = arg_idx + 1;
+            };
+            body_size = locals_decl_size + args_size + 1 + leb_u32_len(callee_index) + 1;
+            out = write_u32_leb(base, out, body_size);
+            if locals_count > 0 {
+                out = write_u32_leb(base, out, local_groups);
+                if local_i32_count > 0 {
+                    out = write_u32_leb(base, out, local_i32_count);
+                    out = write_byte(base, out, wasm_value_type_i32());
                 };
-                let arg_count: i32 = call_metadata_arg_count(metadata_ptr);
-                let args_base: i32 = call_metadata_args_base(metadata_ptr);
-                let mut args_size: i32 = 0;
-                let mut arg_idx: i32 = 0;
-                loop {
-                    if arg_idx >= arg_count {
-                        break;
-                    };
-                    let arg_expr_index: i32 = load_i32(args_base + arg_idx * 4);
-                    let arg_size: i32 = expression_code_size(ast_base, arg_expr_index);
-                    if arg_size < 0 {
-                        return -1;
-                    };
-                    args_size = args_size + arg_size;
-                    arg_idx = arg_idx + 1;
+                if local_i64_count > 0 {
+                    out = write_u32_leb(base, out, local_i64_count);
+                    out = write_byte(base, out, wasm_value_type_i64());
                 };
-                body_size = locals_decl_size + args_size + 1 + leb_u32_len(callee_index) + 1;
-                out = write_u32_leb(base, out, body_size);
-                if locals_count > 0 {
-                    out = write_u32_leb(base, out, local_groups);
-                    if local_i32_count > 0 {
-                        out = write_u32_leb(base, out, local_i32_count);
-                        out = write_byte(base, out, wasm_value_type_i32());
-                    };
-                    if local_i64_count > 0 {
-                        out = write_u32_leb(base, out, local_i64_count);
-                        out = write_byte(base, out, wasm_value_type_i64());
-                    };
-                } else {
-                    out = write_u32_leb(base, out, 0);
-                };
-                let mut emit_idx: i32 = 0;
-                loop {
-                    if emit_idx >= arg_count {
-                        break;
-                    };
-                    let arg_expr_index: i32 = load_i32(args_base + emit_idx * 4);
-                    out = emit_expression(base, out, ast_base, arg_expr_index);
-                    if out < 0 {
-                        return -1;
-                    };
-                    emit_idx = emit_idx + 1;
-                };
-                out = write_byte(base, out, 16);
-                out = write_u32_leb(base, out, callee_index);
-                out = write_byte(base, out, 11);
             } else {
-                let expr_index: i32 = load_i32(entry_ptr + 16);
-                let expr_size: i32 = expression_code_size(ast_base, expr_index);
-                if expr_size < 0 {
-                    return -1;
+                out = write_u32_leb(base, out, 0);
+            };
+            let mut emit_idx: i32 = 0;
+            loop {
+                if emit_idx >= arg_count {
+                    break;
                 };
-                body_size = locals_decl_size + expr_size + 1;
-                out = write_u32_leb(base, out, body_size);
-                if locals_count > 0 {
-                    out = write_u32_leb(base, out, local_groups);
-                    if local_i32_count > 0 {
-                        out = write_u32_leb(base, out, local_i32_count);
-                        out = write_byte(base, out, wasm_value_type_i32());
-                    };
-                    if local_i64_count > 0 {
-                        out = write_u32_leb(base, out, local_i64_count);
-                        out = write_byte(base, out, wasm_value_type_i64());
-                    };
-                } else {
-                    out = write_u32_leb(base, out, 0);
-                };
-                out = emit_expression(base, out, ast_base, expr_index);
+                let arg_expr_index: i32 = load_i32(args_base + emit_idx * 4);
+                out = emit_expression(base, out, ast_base, arg_expr_index);
                 if out < 0 {
                     return -1;
                 };
-                out = write_byte(base, out, 11);
+                emit_idx = emit_idx + 1;
             };
+            out = write_byte(base, out, 16);
+            out = write_u32_leb(base, out, callee_index);
+            out = write_byte(base, out, 11);
+        } else {
+            let expr_index: i32 = load_i32(entry_ptr + 16);
+            let expr_size: i32 = expression_code_size(ast_base, expr_index);
+            if expr_size < 0 {
+                return -1;
+            };
+            body_size = locals_decl_size + expr_size + 1;
+            out = write_u32_leb(base, out, body_size);
+            if locals_count > 0 {
+                out = write_u32_leb(base, out, local_groups);
+                if local_i32_count > 0 {
+                    out = write_u32_leb(base, out, local_i32_count);
+                    out = write_byte(base, out, wasm_value_type_i32());
+                };
+                if local_i64_count > 0 {
+                    out = write_u32_leb(base, out, local_i64_count);
+                    out = write_byte(base, out, wasm_value_type_i64());
+                };
+            } else {
+                out = write_u32_leb(base, out, 0);
+            };
+            out = emit_expression(base, out, ast_base, expr_index);
+            if out < 0 {
+                return -1;
+            };
+            out = write_byte(base, out, 11);
         };
         idx = idx + 1;
     };


### PR DESCRIPTION
## Summary
- replace nested conditional ladders in the AST compiler with direct `else if` chains now that the language supports them
- simplify intrinsic selection, relational parsing, and opcode generation to use clearer `else if` logic
- update resolver and emitter branches to match the new style

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68e5765b683c8329a924799b4a48e1cd