### PR TITLE
Document array semantics and stage2 type metadata layout

### DIFF
--- a/concept.md
+++ b/concept.md
@@ -17,7 +17,12 @@ New programming language:
     * Enum
     * Tuple
     * Unit(0 length tuple)
-    * Array
+* Array
+    * Written using Rust-style syntax: `[T; N]` declares an array that stores `N` consecutive values of type `T` inline.
+    * The length `N` is part of the type and must be a compile-time constant (a literal, `const`, or `type` expression); arrays cannot grow or shrink at runtime.
+    * Array literals follow the host expression syntax: `[a, b, c]` lists each element explicitly, while `[value; N]` repeats the same initializer `N` times when `value` is `Copy`.
+    * Arrays own their contents. Moving an array moves all of its elements, and borrows (`&[T; N]` / `&mut [T; N]`) lock the entire array for the duration of the borrow just like any other aggregate value. Shared borrows may produce slice views, but the array itself cannot be moved or mutably borrowed while a shared borrow is outstanding.
+    * Taking a slice (`&arr[..]`) yields a `slice` type that borrows the array memory without copying; slices keep the underlying array alive until the borrow ends.
     * Slice
     * Numbers (depending on target)
         * u8, u16, u32, u64

--- a/docs/stage2_developer_notes.md
+++ b/docs/stage2_developer_notes.md
@@ -1,0 +1,16 @@
+# Stage-2 Developer Notes
+
+## Type metadata layout
+
+Stage 2 builds a scratch type table in linear memory immediately before the legacy stage-1 function metadata. Each entry is 16 bytes wide and follows the offsets defined in `compiler/ast_compiler.bp` (`TYPE_ENTRY_TYPE_ID_OFFSET`, `TYPE_ENTRY_NAME_PTR_OFFSET`, `TYPE_ENTRY_NAME_LEN_OFFSET`, and `TYPE_ENTRY_EXTRA_OFFSET`). The table base is computed from `scratch_types_base(out_ptr)` and its capacity is fixed at 2,048 entries so the runtime can binary-search or linearly scan without bumping into the function table.
+
+```
++0  (i32) type_id      -> enum describing the high-level type (builtin, struct, array, etc.)
++4  (i32) name_ptr     -> absolute pointer to the UTF-8 type name in the scratch names arena
++8  (i32) name_len     -> byte length of the name string
++12 (i32) extra_ptr    -> type-specific payload (0 when unused)
+```
+
+Array entries populate `extra_ptr` with the address of a two-word payload written elsewhere in scratch memory. The payload stores the resolved element type ID followed by the compile-time length. Consumers read that block to materialize `[T; N]` facts (element type, stride, and static bound) without re-parsing the AST. Other aggregate kinds (struct, tuple, enum) can later reuse the same convention by pointing `extra_ptr` at a longer record that begins with a word count.
+
+This layout keeps array metadata compact while leaving `TYPE_ENTRY_EXTRA_OFFSET` free to signal richer schemas as the compiler evolves. As long as we zero the `extra_ptr` for scalar and builtin types, existing tooling (e.g., `tests/wasm_harness.rs`) keeps working because it only inspects the name span today but can opt into array support by following the pointer when it is non-zero.


### PR DESCRIPTION
## Summary
- document array syntax, constant-length requirements, and borrow semantics in the language concept guide
- add stage-2 developer notes describing the scratch type table layout and how arrays use TYPE_ENTRY_EXTRA_OFFSET metadata

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e5cbedcf688329af2c17eaff975bf6